### PR TITLE
Winadapter updates for improved Direct3D development

### DIFF
--- a/include/wsl/winadapter.h
+++ b/include/wsl/winadapter.h
@@ -167,8 +167,10 @@ __inline int InlineIsEqualGUID(REFGUID rguid1, REFGUID rguid2)
 #define _Success_(x)
 #define _In_count_(x)
 #define _In_opt_count_(x)
+#define _Use_decl_annotations_
 
 // Calling conventions
+#define __cdecl
 #define __stdcall
 #define STDMETHODCALLTYPE
 #define STDAPICALLTYPE
@@ -181,12 +183,20 @@ __inline int InlineIsEqualGUID(REFGUID rguid1, REFGUID rguid2)
 
 // Error codes
 typedef LONG HRESULT;
-#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
-#define FAILED(hr) (((HRESULT)(hr)) < 0)
-#define S_OK ((HRESULT)0L)
-#define E_OUTOFMEMORY 0x80000002L
-#define E_INVALIDARG  0x80000003L
-#define E_NOINTERFACE 0x80000004L
+#define SUCCEEDED(hr)  (((HRESULT)(hr)) >= 0)
+#define FAILED(hr)     (((HRESULT)(hr)) < 0)
+#define S_OK           ((HRESULT)0L)
+#define S_FALSE        ((HRESULT)1L)
+#define E_NOTIMPL      ((HRESULT)0x80000001L)
+#define E_OUTOFMEMORY  ((HRESULT)0x80000002L)
+#define E_INVALIDARG   ((HRESULT)0x80000003L)
+#define E_NOINTERFACE  ((HRESULT)0x80000004L)
+#define E_POINTER      ((HRESULT)0x80000005L)
+#define E_HANDLE       ((HRESULT)0x80000006L)
+#define E_ABORT        ((HRESULT)0x80000007L)
+#define E_FAIL         ((HRESULT)0x80000008L)
+#define E_ACCESSDENIED ((HRESULT)0x80000009L)
+#define E_UNEXPECTED   ((HRESULT)0x8000FFFFL)
 #define DXGI_ERROR_DEVICE_HUNG ((HRESULT)0x887A0006L)
 #define DXGI_ERROR_DEVICE_REMOVED ((HRESULT)0x887A0005L)
 #define DXGI_ERROR_DEVICE_RESET ((HRESULT)0x887A0007L)
@@ -313,4 +323,18 @@ extern "C++"
 }
 
 #define IID_PPV_ARGS(ppType) __uuidof(**(ppType)), IID_PPV_ARGS_Helper(ppType)
+#endif
+
+#if defined(lint)
+// Note: lint -e530 says don't complain about uninitialized variables for
+// this variable.  Error 527 has to do with unreachable code.
+// -restore restores checking to the -save state
+#define UNREFERENCED_PARAMETER(P) \
+    /*lint -save -e527 -e530 */ \
+    { \
+        (P) = (P); \
+    } \
+    /*lint -restore */
+#else
+#define UNREFERENCED_PARAMETER(P) (P)
 #endif

--- a/include/wsl/wrladapter.h
+++ b/include/wsl/wrladapter.h
@@ -7,6 +7,9 @@
 
 // defined by winadapter.h and needed by some windows headers, but conflicts
 // with some libc++ implementation headers
+#ifdef __in
+#undef __in
+#endif
 #ifdef __out
 #undef __out
 #endif


### PR DESCRIPTION
The existing ``wsl`` headers are sufficient to build the test, but they are missing some things that would help in more realistic client scenarios. Case-in-point, I'm working on getting [DirectXMesh](https://github.com/microsoft/DirectXMesh/tree/wsl),[DirectXTex](https://github.com/microsoft/DirectXTex/tree/wsl), and [UVAtlas](https://github.com/microsoft/UVAtlas/tree/wsl) to build for *Windows Subsystem for Linux* leveraging these headers.

The good news is that not much needs to be added:

* SAL2 adapters needs ``_Use_decl_annotations_`` which is used in client code that is SAL2 annotated to avoid having to duplicate the annotations in both the definitions and declarations
* Much like ``__stdcall``, I make use of ``__cdecl`` in my headers and GNU fails on them. They are both Microsoft-specific and in fact specific to x86.
* Adding the rest of the [Common HRESULT Values](https://docs.microsoft.com/en-us/windows/win32/seccrypto/common-hresult-values) errors means that most of my code doesn't have to change. I only have to deal with use cases of ``HRESULT_FROM_WIN32``.
* The ``UNREFERENCED_PARAMETER`` macro is another common use in client code.
* Just like ``__out`` caused problems with GNU's ``<algorithm>``, ``__in`` causes problems for GNU's ``<utility>``.

