### PR TITLE
d3dx12.h: Split a complex expression to prevent analysis warning

### DIFF
--- a/include/directx/d3dx12.h
+++ b/include/directx/d3dx12.h
@@ -2400,7 +2400,8 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
                         {
                             if (desc_1_1.pParameters[n].ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE)
                             {
-                                HeapFree(GetProcessHeap(), 0, reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(pParameters_1_0[n].DescriptorTable.pDescriptorRanges)));
+                                auto pDescriptorRanges_1_0 = pParameters_1_0[n].DescriptorTable.pDescriptorRanges;
+                                HeapFree(GetProcessHeap(), 0, reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges_1_0)));
                             }
                         }
                         HeapFree(GetProcessHeap(), 0, pParameters);


### PR DESCRIPTION
Fixes #5 for me. I think this must be an analysis bug, because the new code is exactly equivalent.