### PR TITLE
Added namespaced target aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,12 @@ if (NOT WIN32)
     )
 endif()
 
+add_library(Micrsofot::DirectX-Headers ALIAS DirectX-Headers)
+
 add_library(DirectX-Guids STATIC src/dxguids.cpp)
 target_link_libraries(DirectX-Guids PRIVATE DirectX-Headers)
+
+add_library(Microsoft::DirectX-Guids ALIAS DirectX-Guids)
 
 # Install the targets
 install(TARGETS DirectX-Headers DirectX-Guids
@@ -62,5 +66,5 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/directx-headers-config.cmake"
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/directx-headers/cmake)
 
 if (BUILD_TEST)
-    add_subdirectory(test)
+    add_subdirectory(test) 
 endif()


### PR DESCRIPTION
When installing this library, all targets are exported with the prefix
    "Microsoft::"
However, when using this project via `add_subdirectory` all targets lack the
prefix.

Due to this, users were required to change the name by which they reference
targets exported by this project depending on the strategy they use to include
this project.

This problem is being solved by adding an alias i.e.:
`    add_library(Microsoft::DirectX-Headers ALIAS DirectX-Headers)`