### PR TITLE
Add typedef for ULONG_PTR

### DIFF
--- a/include/wsl/winadapter.h
+++ b/include/wsl/winadapter.h
@@ -22,7 +22,7 @@ typedef uint16_t UINT16;
 typedef int16_t INT16;
 typedef uint32_t UINT32, UINT, ULONG, DWORD, BOOL;
 typedef int32_t INT32, INT, LONG;
-typedef uint64_t UINT64;
+typedef uint64_t UINT64, ULONG_PTR;
 typedef int64_t INT64, LONG_PTR;
 typedef void VOID, *HANDLE, *RPC_IF_HANDLE, *LPVOID;
 typedef const void *LPCVOID;


### PR DESCRIPTION
I transitioned TF over to using the headers from this repo (long overdue) and noticed a missing typedef: ULONG_PTR. This is referenced in d3dx12.h.