### PR TITLE
Update README.md with link to DX Landing Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository hosts the official Direct3D 12 headers. These headers are made a
 
 Additionally, this repository hosts several helpers for using these headers.
 
+Make sure that you visit the [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-page/) for more resources for DirectX developers.
+
 ## Directory Structure
 
 * `/`: Build files are available here for quick integration. CMake is provided, and can be referenced either via `subdirectory()` or after installation to a system location. Meson is also available for inclusion as a subproject/wrap.


### PR DESCRIPTION
Added link to the DirectX Landing Page at the top of this readme to make sure all DX-related components link back to our new single source of truth.