### PR TITLE
Fix mismatched new[]/delete and more UB in ComPtr

### DIFF
--- a/include/wsl/wrladapter.h
+++ b/include/wsl/wrladapter.h
@@ -716,7 +716,7 @@ namespace WRL
                 ULONG ref = InternalRelease();
                 if (ref == 0)
                 {
-                    delete this;
+                    delete[] this;
                 }
 
                 return ref;

--- a/include/wsl/wrladapter.h
+++ b/include/wsl/wrladapter.h
@@ -17,6 +17,7 @@
 #include <type_traits>
 #include <atomic>
 #include <memory>
+#include <new>
 #include <climits>
 #include <cassert>
 
@@ -716,7 +717,8 @@ namespace WRL
                 ULONG ref = InternalRelease();
                 if (ref == 0)
                 {
-                    delete[] this;
+
+                    delete this;
                 }
 
                 return ref;
@@ -776,17 +778,7 @@ namespace WRL
     template <typename T, typename ...TArgs>
     ComPtr<T> Make(TArgs&&... args)
     {
-        ComPtr<T> object;
-
-        std::unique_ptr<unsigned char[]> buffer(new unsigned char[sizeof(T)]);
-        if (buffer)
-        {
-            T* ptr = new (buffer.get())T(std::forward<TArgs>(args)...);
-            object.Attach(ptr);
-            buffer.release();
-        }
-
-        return object;
+        return ComPtr<T>{new(std::nothrow) T(std::forward<TArgs>(args)...)};
     }
 
     using Details::ChainInterfaces;


### PR DESCRIPTION
Fix bugs and undefined behavior in ComPtr.

* Memory was allocated with the `new[]` allocator and freed with `delete`
* Memory was allocated as `char[]` and freed as `RuntimeClassImpl`
* `Make` was throwing an exception instead of returning a null pointer when allocation fails (it was calling the throwing version of `new`, which throws when the allocation fails instead of returning null, so `if (buffer)` was always true if it was reached)

If someone more knowledgeable of COM can take a look and check it's alright, that would be great :)