### PR TITLE
Fix memory leak in ComPtr initialization

### DIFF
--- a/include/wsl/wrladapter.h
+++ b/include/wsl/wrladapter.h
@@ -779,12 +779,16 @@ namespace WRL
     ComPtr<T> Make(TArgs&&... args)
     {
         std::unique_ptr<char[]> buffer(new(std::nothrow) char[sizeof(T)]);
+        ComPtr<T> object;
+
         if (buffer)
         {
-            new (buffer.get())T(std::forward<TArgs>(args)...);
+            T* ptr = new (buffer.get())T(std::forward<TArgs>(args)...);
+            object.Attach(ptr);
+            buffer.release();
         }
 
-        return ComPtr<T>{reinterpret_cast<T*>(buffer.release())};
+        return object;
     }
 
     using Details::ChainInterfaces;


### PR DESCRIPTION
Calling the constructor of `ComPtr` doesn't do the same thing as `Attach()`. We were increasing the refcount once when creating the object and a second time when calling `ComPtr()`, instead of simply increasing it once and then attaching it to the `ComPtr`.