### PR TITLE
Move the NO_STATE_OBJECT_HELPERS guard

### DIFF
--- a/include/directx/d3dx12.h
+++ b/include/directx/d3dx12.h
@@ -4037,6 +4037,8 @@ private:
     D3D12_NODE_MASK m_Desc;
 };
 
+#endif // #ifndef D3DX12_NO_STATE_OBJECT_HELPERS
+
 //------------------------------------------------------------------------------------------------
 class CD3DX12FeatureSupport
 {
@@ -4876,7 +4878,6 @@ HRESULT CD3DX12FeatureSupport::QueryProtectedResourceSessionTypes(UINT NodeIndex
 #undef D3DX12_COM_PTR
 #undef D3DX12_COM_PTR_GET
 #undef D3DX12_COM_PTR_ADDRESSOF
-#endif // #ifndef D3DX12_NO_STATE_OBJECT_HELPERS
 
 #endif // defined( __cplusplus )
 


### PR DESCRIPTION
This moves the `NO_STATE_OBJECT_HELPERS` guard so that `CD3DX12FeatureSupport` can be used without state object helpers.
Otherwise if `D3DX12_NO_STATE_OBJECT_HELPERS` is defined, CD3DX12FeatureSupport will be excluded as well.

