### PR TITLE
D3DX12.H updated to resolve warnings in MSVC/clang

### DIFF
--- a/include/directx/d3dx12.h
+++ b/include/directx/d3dx12.h
@@ -3079,7 +3079,7 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
     {
         BYTE* pStream = static_cast<BYTE*>(Desc.pPipelineStateSubobjectStream)+CurOffset;
         auto SubobjectType = *reinterpret_cast<D3D12_PIPELINE_STATE_SUBOBJECT_TYPE*>(pStream);
-        if (SubobjectType >= D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MAX_VALID)
+        if (SubobjectType < 0 || SubobjectType >= D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MAX_VALID)
         {
             pCallbacks->ErrorUnknownSubobject(SubobjectType);
             return E_INVALIDARG;


### PR DESCRIPTION
* Fixed some C4365,  C26461, C26494, C26496 warnings from VS 2022
* Fixed some warnings from clang v12: -Wtautological-type-limit-compare, -Wold-style-cast
* Added ``constexpr`` to a simple literal const
* Added ``noexcept`` to trivial accessors
* ``inline constexpr`` is redundant: ``constexpr`` implies ``inline`` for functions.
* Trimmed trailing whitespace
