### PR TITLE
d3d12video.h: Fix input/output GetCodecProfile/GetCodecLevel/GetCodecConfiguration SAL annotations

### DIFF
--- a/include/directx/d3d12video.h
+++ b/include/directx/d3d12video.h
@@ -6216,10 +6216,10 @@ EXTERN_C const IID IID_ID3D12VideoEncoder;
         virtual D3D12_VIDEO_ENCODER_CODEC STDMETHODCALLTYPE GetCodec( void) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetCodecProfile( 
-            _Out_  D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile) = 0;
+            _Inout_  D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetCodecConfiguration( 
-            _Out_  D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION dstCodecConfig) = 0;
+            _Inout_  D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION dstCodecConfig) = 0;
         
         virtual DXGI_FORMAT STDMETHODCALLTYPE GetInputFormat( void) = 0;
         
@@ -6404,10 +6404,10 @@ EXTERN_C const IID IID_ID3D12VideoEncoderHeap;
         virtual D3D12_VIDEO_ENCODER_CODEC STDMETHODCALLTYPE GetCodec( void) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetCodecProfile( 
-            _Out_  D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile) = 0;
+            _Inout_  D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetCodecLevel( 
-            _Out_  D3D12_VIDEO_ENCODER_LEVEL_SETTING dstLevel) = 0;
+            _Inout_  D3D12_VIDEO_ENCODER_LEVEL_SETTING dstLevel) = 0;
         
         virtual UINT STDMETHODCALLTYPE GetResolutionListCount( void) = 0;
         

--- a/include/directx/d3d12video.idl
+++ b/include/directx/d3d12video.idl
@@ -2079,8 +2079,8 @@ interface ID3D12VideoEncoder
     UINT GetNodeMask(); 
     D3D12_VIDEO_ENCODER_FLAGS GetEncoderFlags(); 
     D3D12_VIDEO_ENCODER_CODEC GetCodec(); 
-    HRESULT GetCodecProfile([annotation("_Out_")] D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile);
-    HRESULT GetCodecConfiguration([annotation("_Out_")] D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION dstCodecConfig);
+    HRESULT GetCodecProfile([annotation("_Inout_")] D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile);
+    HRESULT GetCodecConfiguration([annotation("_Inout_")] D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION dstCodecConfig);
     DXGI_FORMAT GetInputFormat();
     D3D12_VIDEO_ENCODER_MOTION_ESTIMATION_PRECISION_MODE GetMaxMotionEstimationPrecision();
 }
@@ -2092,8 +2092,8 @@ interface ID3D12VideoEncoderHeap
     UINT GetNodeMask(); 
     D3D12_VIDEO_ENCODER_HEAP_FLAGS GetEncoderHeapFlags(); 
     D3D12_VIDEO_ENCODER_CODEC GetCodec(); 
-    HRESULT GetCodecProfile([annotation("_Out_")] D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile); 
-    HRESULT GetCodecLevel([annotation("_Out_")] D3D12_VIDEO_ENCODER_LEVEL_SETTING dstLevel); 
+    HRESULT GetCodecProfile([annotation("_Inout_")] D3D12_VIDEO_ENCODER_PROFILE_DESC dstProfile); 
+    HRESULT GetCodecLevel([annotation("_Inout_")] D3D12_VIDEO_ENCODER_LEVEL_SETTING dstLevel); 
     UINT GetResolutionListCount(); 
     HRESULT GetResolutionList(
         const UINT ResolutionsListCount,

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -6,6 +6,7 @@
 #endif
 
 #include <directx/d3d12.h>
+#include <directx/d3d12video.h>
 #include <directx/dxcore.h>
 #include <directx/d3dx12.h>
 #include "dxguids/dxguids.h"


### PR DESCRIPTION
* d3d12video.h: Fix input/output GetCodecProfile/GetCodecLevel/GetCodecConfiguration SAL annotations
* Add include<directx/d3d12video.h> to test for build validation