### PR TITLE
Added missing relational operators for D3D12_RECT

### DIFF
--- a/include/directx/d3dx12.h
+++ b/include/directx/d3dx12.h
@@ -47,6 +47,16 @@ struct CD3DX12_RECT : public D3D12_RECT
 };
 
 //------------------------------------------------------------------------------------------------
+inline bool operator==(const D3D12_RECT& l, const D3D12_RECT& r) noexcept
+{
+	return l.bottom == r.bottom && l.left == r.left && l.right == r.right && l.top == r.top;
+}
+
+//------------------------------------------------------------------------------------------------
+inline bool operator!=(const D3D12_RECT& l, const D3D12_RECT& r) noexcept
+{ return !(l == r); }
+
+//------------------------------------------------------------------------------------------------
 struct CD3DX12_VIEWPORT : public D3D12_VIEWPORT
 {
     CD3DX12_VIEWPORT() = default;


### PR DESCRIPTION
Added mising *equal to* and *not equal to* operators for `D3D12_RECT`.