### PR TITLE
D3D12_FEATURE_DATA_D3D12_OPTIONS12 API support for CD3DX12FeatureSupport

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -6,7 +6,7 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG master # Live at head
+    GIT_TAG main # Live at head
 )
 FetchContent_MakeAvailable(googletest)
 

--- a/googletest/MockDevice.hpp
+++ b/googletest/MockDevice.hpp
@@ -1043,7 +1043,21 @@ public: // IUnknown
 
             pD3D12Options11->AtomicInt64OnDescriptorHeapResourceSupported = m_AtomicInt64OnDescriptorHeapResourceSupported;
         } return S_OK;
-        
+        case D3D12_FEATURE_D3D12_OPTIONS12:
+        {
+            if (!m_Options12Available)
+            {
+                return E_INVALIDARG;
+            }
+			D3D12_FEATURE_DATA_D3D12_OPTIONS12* pD3D12Options12 = static_cast<D3D12_FEATURE_DATA_D3D12_OPTIONS12*>(pFeatureSupportData);
+			if (FeatureSupportDataSize != sizeof(*pD3D12Options12))
+			{
+				return E_INVALIDARG;
+			}
+
+            pD3D12Options12->MSPrimitivesPipelineStatisticIncludesCulledPrimitives = m_MSPrimitivesPipelineStatisticIncludesCulledPrimitives;
+            pD3D12Options12->EnhancedBarriersSupported = m_EnhancedBarriersSupported;
+        } return S_OK;
 
         default:
             return E_INVALIDARG;
@@ -1228,6 +1242,11 @@ public: // For simplicity, allow tests to set the internal state values for this
     // 40: Options11
     bool m_Options11Available = true;
     bool m_AtomicInt64OnDescriptorHeapResourceSupported = false;
+
+    // 41: Options12
+    bool m_Options12Available = true;
+    D3D12_TRI_STATE m_MSPrimitivesPipelineStatisticIncludesCulledPrimitives = D3D12_TRI_STATE_UNKNOWN;
+    bool m_EnhancedBarriersSupported = false;
 };
 
 #endif

--- a/googletest/feature_support_test.cpp
+++ b/googletest/feature_support_test.cpp
@@ -608,12 +608,12 @@ TEST_F(FeatureSupportTest, ExistingHeapsUnavailable)
 TEST_F(FeatureSupportTest, Options4Basic)
 {
     device->m_MSAA64KBAlignedTextureSupported = true;
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3; // Duplicate member
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2; // Duplicate member
     device->m_Native16BitShaderOpsSupported = true;
 
     INIT_FEATURES();
     EXPECT_TRUE(features.MSAA64KBAlignedTextureSupported());
-    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3);
+    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2);
     EXPECT_TRUE(features.Native16BitShaderOpsSupported());
 }
 
@@ -622,7 +622,7 @@ TEST_F(FeatureSupportTest, Options4Unavailable)
 {
     device->m_Options4Available = false;
     device->m_MSAA64KBAlignedTextureSupported = true;
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3; // Duplicate member
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2; // Duplicate member
     device->m_Native16BitShaderOpsSupported = true;
 
     INIT_FEATURES();
@@ -740,12 +740,12 @@ TEST_F(FeatureSupportTest, Options5Unavailable)
 TEST_F(FeatureSupportTest, DisplayableBasic)
 {
     device->m_DisplayableTexture = true;
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3;
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2;
 
     INIT_FEATURES();
 
     EXPECT_TRUE(features.DisplayableTexture());
-    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3);
+    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2);
 }
 
 // Unavailable Test
@@ -753,12 +753,12 @@ TEST_F(FeatureSupportTest, DisplayableUnavailable)
 {
     device->m_DisplayableAvailable = false;
     device->m_DisplayableTexture = true;
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3;
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2;
 
     INIT_FEATURES();
 
     EXPECT_FALSE(features.DisplayableTexture());
-    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3); // Still initialized by Options4
+    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2); // Still initialized by Options4
 }
 
 // 30: D3D12 Options6
@@ -1062,6 +1062,28 @@ TEST_F(FeatureSupportTest, Options11Unavailable)
     EXPECT_FALSE(features.AtomicInt64OnDescriptorHeapResourceSupported());
 }
 
+// 41: Options12
+// Basic Test
+TEST_F(FeatureSupportTest, Options12Basic)
+{
+    device->m_MSPrimitivesPipelineStatisticIncludesCulledPrimitives = D3D12_TRI_STATE_TRUE;
+    device->m_EnhancedBarriersSupported = true;
+    INIT_FEATURES();
+    EXPECT_EQ(features.MSPrimitivesPipelineStatisticIncludesCulledPrimitives(), D3D12_TRI_STATE_TRUE);
+    EXPECT_TRUE(features.EnhancedBarriersSupported());
+}
+
+// Unavailable Test
+TEST_F(FeatureSupportTest, Options12Unavailable)
+{
+	device->m_Options12Available = false;
+	device->m_MSPrimitivesPipelineStatisticIncludesCulledPrimitives = D3D12_TRI_STATE_TRUE;
+	device->m_EnhancedBarriersSupported = true;
+	INIT_FEATURES();
+	EXPECT_EQ(features.MSPrimitivesPipelineStatisticIncludesCulledPrimitives(), D3D12_TRI_STATE_UNKNOWN);
+    EXPECT_FALSE(features.EnhancedBarriersSupported());
+}
+
 // Duplicate Caps Tests
 // This test ensures that caps that are present in more than one features reports correctly
 // when either of them are unavailable on the runtime
@@ -1080,17 +1102,17 @@ TEST_F(FeatureSupportTest, DuplicateCrossNodeSharingTier)
 // Shared Resource Compatibility Tier: D3D12Options4, Displayable
 TEST_F(FeatureSupportTest, DuplicateSharedResourceCompatibilityTier)
 {
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3;
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2;
     device->m_DisplayableAvailable = false;
 
     INIT_FEATURES();
-    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3);
+    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2);
 }
 
 // Test where both features are unavailable
 TEST_F(FeatureSupportTest, DuplicateSharedResourceCompatibilityTierNegatvie)
 {
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3;
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2;
     device->m_DisplayableAvailable = false;
     device->m_Options4Available = false;
 
@@ -1171,7 +1193,7 @@ TEST_F(FeatureSupportTest, SystemTest)
     device->m_ExistingHeapCaps = true;
 
     device->m_MSAA64KBAlignedTextureSupported = true;
-    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3;
+    device->m_SharedResourceCompatibilityTier = D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2;
     device->m_Native16BitShaderOpsSupported = true;
 
     device->m_HeapSerializationTier = 
@@ -1217,6 +1239,9 @@ TEST_F(FeatureSupportTest, SystemTest)
     device->m_MeshShaderPerPrimitiveShadingRateSupported = true;
 
     device->m_AtomicInt64OnDescriptorHeapResourceSupported = true;
+
+    device->m_MSPrimitivesPipelineStatisticIncludesCulledPrimitives = D3D12_TRI_STATE_TRUE;
+    device->m_EnhancedBarriersSupported = true;
 
     INIT_FEATURES();
 
@@ -1279,7 +1304,7 @@ TEST_F(FeatureSupportTest, SystemTest)
     EXPECT_TRUE(features.ExistingHeapsSupported());
 
     EXPECT_TRUE(features.MSAA64KBAlignedTextureSupported());
-    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3);
+    EXPECT_EQ(features.SharedResourceCompatibilityTier(), D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_2);
     EXPECT_TRUE(features.Native16BitShaderOpsSupported());
 
     EXPECT_EQ(features.HeapSerializationTier(), D3D12_HEAP_SERIALIZATION_TIER_10);
@@ -1321,4 +1346,7 @@ TEST_F(FeatureSupportTest, SystemTest)
     EXPECT_TRUE(features.MeshShaderPerPrimitiveShadingRateSupported());
 
     EXPECT_TRUE(features.AtomicInt64OnDescriptorHeapResourceSupported());
+
+    EXPECT_EQ(features.MSPrimitivesPipelineStatisticIncludesCulledPrimitives(), D3D12_TRI_STATE_TRUE);
+    EXPECT_TRUE(features.EnhancedBarriersSupported());
 }

--- a/include/directx/d3dx12.h
+++ b/include/directx/d3dx12.h
@@ -4313,6 +4313,10 @@ public: // Function declaration
     // D3D12_OPTIONS11
     BOOL AtomicInt64OnDescriptorHeapResourceSupported() const noexcept;
 
+    // D3D12_OPTIONS12
+    D3D12_TRI_STATE MSPrimitivesPipelineStatisticIncludesCulledPrimitives() const noexcept;
+    BOOL EnhancedBarriersSupported() const noexcept;
+
 private: // Private structs and helpers declaration
     struct ProtectedResourceSessionTypesLocal : D3D12_FEATURE_DATA_PROTECTED_RESOURCE_SESSION_TYPES
     {
@@ -4368,6 +4372,7 @@ private: // Member data
     D3D12_FEATURE_DATA_D3D12_OPTIONS9 m_dOptions9;
     D3D12_FEATURE_DATA_D3D12_OPTIONS10 m_dOptions10;
     D3D12_FEATURE_DATA_D3D12_OPTIONS11 m_dOptions11;
+    D3D12_FEATURE_DATA_D3D12_OPTIONS12 m_dOptions12;
 };
 
 // Implementations for CD3DX12FeatureSupport functions
@@ -4566,6 +4571,12 @@ inline HRESULT CD3DX12FeatureSupport::Init(ID3D12Device* pDevice)
     if (FAILED(m_pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS11, &m_dOptions11, sizeof(m_dOptions11))))
     {
         m_dOptions11.AtomicInt64OnDescriptorHeapResourceSupported = false;
+    }
+
+    if (FAILED(m_pDevice->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS12, &m_dOptions12, sizeof(m_dOptions12))))
+    {
+        m_dOptions12.MSPrimitivesPipelineStatisticIncludesCulledPrimitives = D3D12_TRI_STATE_UNKNOWN;
+        m_dOptions12.EnhancedBarriersSupported = false;
     }
 
     // Initialize per-node feature support data structures
@@ -4873,6 +4884,10 @@ FEATURE_SUPPORT_GET(BOOL, m_dOptions10, MeshShaderPerPrimitiveShadingRateSupport
 
 // 40: Options11
 FEATURE_SUPPORT_GET(BOOL, m_dOptions11, AtomicInt64OnDescriptorHeapResourceSupported);
+
+// 41: Options12
+FEATURE_SUPPORT_GET(D3D12_TRI_STATE, m_dOptions12, MSPrimitivesPipelineStatisticIncludesCulledPrimitives);
+FEATURE_SUPPORT_GET(BOOL, m_dOptions12, EnhancedBarriersSupported);
 
 // Helper function to decide the highest shader model supported by the system
 // Stores the result in m_dShaderModel

--- a/test/feature_check_test.cpp
+++ b/test/feature_check_test.cpp
@@ -619,6 +619,17 @@ int main()
         VERIFY_FEATURE_CHECK(AtomicInt64OnDescriptorHeapResourceSupported, false);
     }
 
+    // 41: Options12
+    {
+        D3D12_TRI_STATE MSPrimitivesPipelineStatisticIncludesCulledPrimitives = features.MSPrimitivesPipelineStatisticIncludesCulledPrimitives();
+        BOOL EnhancedBarriersSupported = features.EnhancedBarriersSupported();
+
+        D3D12_FEATURE_DATA_D3D12_OPTIONS12 Data;
+        INITIALIZE_FEATURE_SUPPORT_DATA(D3D12_OPTIONS12);
+        VERIFY_FEATURE_CHECK(MSPrimitivesPipelineStatisticIncludesCulledPrimitives, D3D12_TRI_STATE_UNKNOWN);
+        VERIFY_FEATURE_CHECK(EnhancedBarriersSupported, false);
+    }
+
     std::cout << "Test completed with no errors." << std::endl;
     return 0;
 }


### PR DESCRIPTION
- Added API support for D3D12_FEATURE_DATA_D3D12_OPTIONS12 in CD3DX12FeatureSupport.
- Added feature support/check tests.
- Removed usage of D3D12_SHARED_RESOURCE_COMPATIBILITY_TIER_3 as they were removed in the new header.
- Updated FetchContent_Declare for googletest to use the main branch, master branch no longer exists.