### PR TITLE
Make the tests compatible with WSL

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -1,15 +1,34 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-include(FetchContent)
 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG main # Live at head
-)
-FetchContent_MakeAvailable(googletest)
+# Assume to use vcpkg to install gtest
+list(APPEND gtestlibs "")
+if("${CMAKE_TOOLCHAIN_FILE}" MATCHES "vcpkg.cmake$")
+  find_package(GTest CONFIG REQUIRED)
+  list(APPEND gtestlibs GTest::gtest_main)
+else()
+  include(FetchContent)
+
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG main # Live at head
+  )
+  FetchContent_MakeAvailable(googletest)
+  list(APPEND gtestlibs gtest_main)
+endif()
+
+list(APPEND dxlibs "")
+if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
+  find_library(libd3d12 d3d12 HINTS /lib/wsl/lib)
+  find_library(libdxcore dxcore HINTS /lib/wsl/lib)
+  list(APPEND dxlibs ${libd3d12} ${libdxcore})
+else()
+# Fallback to default: let CMake to looking for libs
+  list(APPEND dxlibs d3d12 dxcore)
+endif()
 
 project(DirectX-Headers-GoogleTest-Suite CXX)
 add_executable(Feature-Support-Test feature_support_test.cpp)
-target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids d3d12 dxcore gtest_main)
+target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} ${gtestlibs})

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -16,7 +16,7 @@ if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
   find_library(libdxcore dxcore HINTS /lib/wsl/lib)
   list(APPEND dxlibs ${libd3d12} ${libdxcore})
 else()
-# Fallback to default: let CMake to looking for libs
+# Fallback to default: let CMake look for libs
   list(APPEND dxlibs d3d12 dxcore)
 endif()
 

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -1,23 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
+include(FetchContent)
 
-# Assume to use vcpkg to install gtest
-list(APPEND gtestlibs "")
-if("${CMAKE_TOOLCHAIN_FILE}" MATCHES "vcpkg.cmake$")
-  find_package(GTest CONFIG REQUIRED)
-  list(APPEND gtestlibs GTest::gtest_main)
-else()
-  include(FetchContent)
-
-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-  FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG main # Live at head
-  )
-  FetchContent_MakeAvailable(googletest)
-  list(APPEND gtestlibs gtest_main)
-endif()
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG main # Live at head
+)
+FetchContent_MakeAvailable(googletest)
 
 list(APPEND dxlibs "")
 if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
@@ -31,4 +22,4 @@ endif()
 
 project(DirectX-Headers-GoogleTest-Suite CXX)
 add_executable(Feature-Support-Test feature_support_test.cpp)
-target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} ${gtestlibs})
+target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} gtest_main)

--- a/googletest/MockDevice.hpp
+++ b/googletest/MockDevice.hpp
@@ -4,6 +4,10 @@
 #define DIRECTX_HEADERS_MOCK_DEVICE_HPP
 #include <unordered_map>
 
+#ifndef __RPC_FAR
+#define __RPC_FAR
+#endif
+
 #include <directx/d3d12.h>
 #include <directx/dxcore.h>
 #include <directx/d3dx12.h>
@@ -502,7 +506,7 @@ public: // IUnknown
             default:
                 return E_INVALIDARG;
             }
-            pRootSig->HighestVersion = min(pRootSig->HighestVersion, m_RootSignatureHighestVersion); 
+            pRootSig->HighestVersion = std::min(pRootSig->HighestVersion, m_RootSignatureHighestVersion); 
         } return S_OK;
         
 
@@ -699,7 +703,7 @@ public: // IUnknown
                 default:
                     return E_INVALIDARG;
                 }
-                pSM->HighestShaderModel = min(pSM->HighestShaderModel,m_HighestSupportedShaderModel);
+                pSM->HighestShaderModel = std::min(pSM->HighestShaderModel,m_HighestSupportedShaderModel);
             } return S_OK;
         case D3D12_FEATURE_SHADER_CACHE:
             {

--- a/googletest/feature_support_test.cpp
+++ b/googletest/feature_support_test.cpp
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 #include "gtest/gtest.h"
 
+#ifndef _WIN32
+#include <wsl/winadapter.h>
+#endif
+
 #include <directx/d3d12.h>
 #include <directx/dxcore.h>
 #include <directx/d3dx12.h>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
   find_library(libdxcore dxcore HINTS /lib/wsl/lib)
   list(APPEND dxlibs ${libd3d12} ${libdxcore})
 else()
-# Fallback to default: let CMake to looking for libs
+# Fallback to default: let CMake look for libs
   list(APPEND dxlibs d3d12 dxcore)
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,20 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+list(APPEND dxlibs "")
+# Check if in WSL and if has DirectX driver and runtime
+if(EXISTS "/dev/dxg" AND EXISTS "/lib/wsl/lib/")
+  find_library(libd3d12 d3d12 HINTS /lib/wsl/lib)
+  find_library(libdxcore dxcore HINTS /lib/wsl/lib)
+  list(APPEND dxlibs ${libd3d12} ${libdxcore})
+else()
+# Fallback to default: let CMake to looking for libs
+  list(APPEND dxlibs d3d12 dxcore)
+endif()
+
 project(DirectX-Headers-Test CXX)
 add_executable(DirectX-Headers-Test test.cpp)
-target_link_libraries(DirectX-Headers-Test DirectX-Headers DirectX-Guids d3d12 dxcore)
+target_link_libraries(DirectX-Headers-Test DirectX-Headers DirectX-Guids ${dxlibs})
 
 add_executable(DirectX-Headers-Check-Feature-Support-Test feature_check_test.cpp)
-target_link_libraries(DirectX-Headers-Check-Feature-Support-Test DirectX-Headers DirectX-Guids d3d12 dxcore)
+target_link_libraries(DirectX-Headers-Check-Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs})

--- a/test/feature_check_test.cpp
+++ b/test/feature_check_test.cpp
@@ -117,7 +117,7 @@ std::string get_driver_description(ComPtr<IDXCoreAdapter> adapter) {
 }
 
 // -----------------------------------------------------------------------------------------------------------------
-// Run test on a specific device which is created from the adapter
+// Run tests on a specific device which is created from the input adapter
 // -----------------------------------------------------------------------------------------------------------------
 int run_per_adapter(IUnknown* adapter)
 {
@@ -669,20 +669,23 @@ int main()
         IID_PPV_ARGS(&adapter_list))))
         return -1;
 
-    // Generate all devices object;
+    // Test all adapters
     for (uint32_t i = 0; i < adapter_list->GetAdapterCount(); i++) {
 
         ComPtr<IDXCoreAdapter> adapter;
         if(FAILED(adapter_list->GetAdapter(i, IID_PPV_ARGS(&adapter))))
-            return -1;
+        {
+            std::cout << "Cannot get number " << i << " adapter." << std::endl;
+            continue;
+        }
 
         std::string driver_desc_str = get_driver_description(adapter);
         if(driver_desc_str.empty())
-            return -1;
+            std::cout << "Cannot get number " << i << " adapter's driver description." << std::endl;
         std::cout << "Test on device driver: " << driver_desc_str << std::endl;
 
         if(FAILED(run_per_adapter(adapter.Get())))
-            return -1;
+            std::cout << "Some tests failed with error on number " << i << " adapter." << std::endl;
     }
     return 0;
 }

--- a/test/feature_check_test.cpp
+++ b/test/feature_check_test.cpp
@@ -94,14 +94,36 @@ std::cout << "Verification failed: " << #FeatureName << std::endl \
           << "New API: " << NewFeature << std::endl;
 
 
+using namespace Microsoft::WRL;
+
+// To get property value from adapter
+std::vector<char> get_adapter_property(ComPtr<IDXCoreAdapter> adapter, DXCoreAdapterProperty property) {
+    if (adapter->IsPropertySupported(property)) {
+        size_t len;
+        if(FAILED(adapter->GetPropertySize(property, &len)))
+            return {};
+        std::vector<char> buf(len);
+        if(FAILED(adapter->GetProperty(property, len, buf.data()))) return {};
+        return buf;
+    }
+    return {};
+}
+
+// To get driver description for display before test
+std::string get_driver_description(ComPtr<IDXCoreAdapter> adapter) {
+    auto rs = get_adapter_property(adapter, DXCoreAdapterProperty::DriverDescription);
+    std::string name(rs.data());
+    return name;
+}
+
 // -----------------------------------------------------------------------------------------------------------------
-// Main function
+// Run test on a specific device which is created from the adapter
 // -----------------------------------------------------------------------------------------------------------------
-int main()
+int run_per_adapter(IUnknown* adapter)
 {
     ID3D12Device *device = nullptr;
 
-    if (FAILED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device)))) 
+    if (FAILED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device)))) 
     {
         return -1;
     }
@@ -631,5 +653,36 @@ int main()
     }
 
     std::cout << "Test completed with no errors." << std::endl;
+    return 0;
+}
+
+int main()
+{
+    ComPtr<IDXCoreAdapterFactory> adapter_factory;
+    ComPtr<IDXCoreAdapterList> adapter_list;
+    GUID dx_must_attr[1]{ DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
+
+    if(FAILED(DXCoreCreateAdapterFactory(IID_PPV_ARGS(&adapter_factory))))
+        return -1;
+
+    if(FAILED(adapter_factory->CreateAdapterList(_countof(dx_must_attr), dx_must_attr,
+        IID_PPV_ARGS(&adapter_list))))
+        return -1;
+
+    // Generate all devices object;
+    for (uint32_t i = 0; i < adapter_list->GetAdapterCount(); i++) {
+
+        ComPtr<IDXCoreAdapter> adapter;
+        if(FAILED(adapter_list->GetAdapter(i, IID_PPV_ARGS(&adapter))))
+            return -1;
+
+        std::string driver_desc_str = get_driver_description(adapter);
+        if(driver_desc_str.empty())
+            return -1;
+        std::cout << "Test on device driver: " << driver_desc_str << std::endl;
+
+        if(FAILED(run_per_adapter(adapter.Get())))
+            return -1;
+    }
     return 0;
 }

--- a/test/feature_check_test.cpp
+++ b/test/feature_check_test.cpp
@@ -97,20 +97,28 @@ std::cout << "Verification failed: " << #FeatureName << std::endl \
 using namespace Microsoft::WRL;
 
 // To get property value from adapter
-std::vector<char> get_adapter_property(ComPtr<IDXCoreAdapter> adapter, DXCoreAdapterProperty property) {
-    if (adapter->IsPropertySupported(property)) {
+std::vector<char> get_adapter_property(ComPtr<IDXCoreAdapter> adapter, DXCoreAdapterProperty property)
+{
+    if (adapter->IsPropertySupported(property))
+    {
         size_t len;
         if(FAILED(adapter->GetPropertySize(property, &len)))
+        {
             return {};
+        }
         std::vector<char> buf(len);
-        if(FAILED(adapter->GetProperty(property, len, buf.data()))) return {};
+        if(FAILED(adapter->GetProperty(property, len, buf.data())))
+        {
+            return {};
+        }
         return buf;
     }
     return {};
 }
 
 // To get driver description for display before test
-std::string get_driver_description(ComPtr<IDXCoreAdapter> adapter) {
+std::string get_driver_description(ComPtr<IDXCoreAdapter> adapter)
+{
     auto rs = get_adapter_property(adapter, DXCoreAdapterProperty::DriverDescription);
     std::string name(rs.data());
     return name;
@@ -663,15 +671,18 @@ int main()
     GUID dx_must_attr[1]{ DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE };
 
     if(FAILED(DXCoreCreateAdapterFactory(IID_PPV_ARGS(&adapter_factory))))
+    {
         return -1;
+    }
 
-    if(FAILED(adapter_factory->CreateAdapterList(_countof(dx_must_attr), dx_must_attr,
-        IID_PPV_ARGS(&adapter_list))))
+    if(FAILED(adapter_factory->CreateAdapterList(_countof(dx_must_attr), dx_must_attr, IID_PPV_ARGS(&adapter_list))))
+    {
         return -1;
+    }
 
     // Test all adapters
-    for (uint32_t i = 0; i < adapter_list->GetAdapterCount(); i++) {
-
+    for (uint32_t i = 0; i < adapter_list->GetAdapterCount(); i++)
+    {
         ComPtr<IDXCoreAdapter> adapter;
         if(FAILED(adapter_list->GetAdapter(i, IID_PPV_ARGS(&adapter))))
         {
@@ -681,11 +692,15 @@ int main()
 
         std::string driver_desc_str = get_driver_description(adapter);
         if(driver_desc_str.empty())
+        {
             std::cout << "Cannot get number " << i << " adapter's driver description." << std::endl;
+        }
         std::cout << "Test on device driver: " << driver_desc_str << std::endl;
 
         if(FAILED(run_per_adapter(adapter.Get())))
+        {
             std::cout << "Some tests failed with error on number " << i << " adapter." << std::endl;
+        }
     }
     return 0;
 }


### PR DESCRIPTION
1. Changed CMakeLists.txt in [test/](https://github.com/wenxcs/DirectX-Headers/blob/wenxh/make-test-wsl-compatible/test/CMakeLists.txt) and [googletest/](https://github.com/wenxcs/DirectX-Headers/blob/wenxh/make-test-wsl-compatible/googletest/CMakeLists.txt) to make it easier to find libd3d12.so and libdxcore.so in WSL. 
2. Changed main function in test/feature_check_test.cpp to support enumeration of all supported adapters, since D3D12CreateDevice will crash if set adapter as nullptr in WSL.
3. Fixed some WSL specific problem for test under googletest/.