### PR TITLE
CMake Presets added for Intel compilers

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -60,7 +60,8 @@
       "name": "MSVC",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "cl.exe"
+        "CMAKE_CXX_COMPILER": "cl.exe",
+        "CMAKE_C_COMPILER": "cl.exe"
       },
       "toolset": {
         "value": "host=x64",
@@ -80,12 +81,37 @@
       }
     },
     {
-      "name": "MinGW",
+      "name": "GNUC",
       "hidden": true,
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "g++.exe",
         "CMAKE_C_COMPILER": "gcc.exe",
         "DXHEADERS_BUILD_TEST": false
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "Intel",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "icl.exe",
+        "DXHEADERS_BUILD_GOOGLE_TEST": false,
+        "DXHEADERS_BUILD_TEST": false
+      },
+      "toolset": {
+        "value": "host=x64",
+        "strategy": "external"
+      }
+    },
+    {
+      "name": "IntelLLVM",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "icx.exe",
+        "DXHEADERS_BUILD_GOOGLE_TEST": false
       },
       "toolset": {
         "value": "host=x64",
@@ -130,13 +156,23 @@
     { "name": "x64-Release-Clang"  , "description": "Clang/LLVM for x64 (Release)", "inherits": [ "base", "x64", "Release", "Clang" ] },
     { "name": "x86-Debug-Clang"    , "description": "Clang/LLVM for x86 (Debug)", "inherits": [ "base", "x86", "Debug", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
     { "name": "x86-Release-Clang"  , "description": "Clang/LLVM for x86 (Release)", "inherits": [ "base", "x86", "Release", "Clang" ], "environment": { "CXXFLAGS": "-m32" } },
-    { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug) - ARM-NEON", "inherits": [ "base", "ARM64", "Debug", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
-    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release) - ARM-NEON", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Debug-Clang"  , "description": "Clang/LLVM for AArch64 (Debug)", "inherits": [ "base", "ARM64", "Debug", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
+    { "name": "arm64-Release-Clang", "description": "Clang/LLVM for AArch64 (Release)", "inherits": [ "base", "ARM64", "Release", "Clang" ], "environment": { "CXXFLAGS": "--target=arm64-pc-windows-msvc" } },
 
-    { "name": "x64-Debug-MinGW"  , "description": "MinG-W64 (Debug)", "inherits": [ "base", "x64", "Debug", "MinGW" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "MinGW" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
-    { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "MinGW" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
-    { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "MinGW" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+    { "name": "x64-Debug-ICC"     , "description": "Intel Classic Compiler (Debug)", "inherits": [ "base", "x64", "Debug", "Intel" ] },
+    { "name": "x64-Release-ICC"   , "description": "Intel Classic Compiler (Release)", "inherits": [ "base", "x64", "Release", "Intel" ] },
+    { "name": "x86-Debug-ICC"     , "description": "Intel Classic Compiler (Debug)", "inherits": [ "base", "x86", "Debug", "Intel" ] },
+    { "name": "x86-Release-ICC"   , "description": "Intel Classic Compiler (Release)", "inherits": [ "base", "x86", "Release", "Intel" ] },
+
+    { "name": "x64-Debug-ICX"     , "description": "Intel oneAPI Compiler (Debug)", "inherits": [ "base", "x64", "Debug", "IntelLLVM" ] },
+    { "name": "x64-Release-ICX"   , "description": "Intel oneAPI Compiler (Release)", "inherits": [ "base", "x64", "Release", "IntelLLVM" ] },
+    { "name": "x86-Debug-ICX"     , "description": "Intel oneAPI Compiler (Debug)", "inherits": [ "base", "x86", "Debug", "IntelLLVM" ] },
+    { "name": "x86-Release-ICX"   , "description": "Intel oneAPI Compiler (Release)", "inherits": [ "base", "x86", "Release", "IntelLLVM" ] },
+
+    { "name": "x64-Debug-MinGW"  , "description": "MinG-W64 (Debug)", "inherits": [ "base", "x64", "Debug", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x64-Release-MinGW", "description": "MinG-W64 (Release)", "inherits": [ "base", "x64", "Release", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw64/bin" } },
+    { "name": "x86-Debug-MinGW"  , "description": "MinG-W32 (Debug)", "inherits": [ "base", "x86", "Debug", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
+    { "name": "x86-Release-MinGW", "description": "MinG-W32 (Release)", "inherits": [ "base", "x86", "Release", "GNUC" ], "environment": { "PATH": "$penv{PATH};c:/mingw32/bin" } },
 
     { "name": "x64-Debug-WSL"    , "description": "WSL x64 (Debug) for Windows 11", "inherits": [ "base", "x64", "Debug" ] },
     { "name": "x64-Release-WSL"  , "description": "WSL x64 (Release) for Windows 11", "inherits": [ "base", "x64", "Release" ] },

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ foreach(t IN LISTS TEST_EXES)
   target_link_libraries(${t} DirectX-Headers DirectX-Guids ${dxlibs})
 endforeach()
 
-if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM" )
     target_compile_options(DirectX-Headers-Check-Feature-Support-Test PRIVATE -Wno-unused-variable)
 endif()
 


### PR DESCRIPTION
In addition to having presets for MSVC, clang/LLVM, and MinGW, this adds Presets for using both the new Intel oneAPI compiler and the older Intel Classic Compiler.

```
  "x64-Debug-ICC"
  "x64-Release-ICC"
  "x86-Debug-ICC"
  "x86-Release-ICC"
  "x64-Debug-ICX"
  "x64-Release-ICX"
  "x86-Debug-ICX"
  "x86-Release-ICX"
```

Note that currently neither compiler is supported by the Google Test framework we use, so those tests are turned off.

Also, the Intel Classic Compiler doesn't treat __uuidof as a constexpr, so it can't build the normal tests either.