### PR TITLE
Fixed -Wshadow-field warning in d3dx12.h

### DIFF
--- a/include/directx/d3dx12.h
+++ b/include/directx/d3dx12.h
@@ -4432,20 +4432,20 @@ public:
         D3D12_BARRIER_SUBRESOURCE_RANGE{ Subresource, 0, 0, 0, 0, 0 }
     {}
     CD3DX12_BARRIER_SUBRESOURCE_RANGE(
-        UINT FirstMipLevel,
-        UINT NumMips,
-        UINT FirstArraySlice,
-        UINT NumArraySlices,
-        UINT FirstPlane = 0,
-        UINT NumPlanes = 1) noexcept :
+        UINT firstMipLevel,
+        UINT numMips,
+        UINT firstArraySlice,
+        UINT numArraySlices,
+        UINT firstPlane = 0,
+        UINT numPlanes = 1) noexcept :
         D3D12_BARRIER_SUBRESOURCE_RANGE
         {
-            FirstMipLevel,
-            NumMips,
-            FirstArraySlice,
-            NumArraySlices,
-            FirstPlane,
-            NumPlanes
+            firstMipLevel,
+            numMips,
+            firstArraySlice,
+            numArraySlices,
+            firstPlane,
+            numPlanes
         }
     {}
 };


### PR DESCRIPTION
Fixes the following warnings with clang/LLVM:

```
d3dx12.h(4118,14): warning : parameter 'FirstArraySlice' shadows member inherited from type 'D3D12_BARRIER_SUBRESOURCE_RANGE' [-Wshadow-field] 
d3dx12.h(4119,14): warning : parameter 'NumArraySlices' shadows member inherited from type 'D3D12_BARRIER_SUBRESOURCE_RANGE' [-Wshadow-field] 
d3dx12.h(4120,14): warning : parameter 'FirstPlane' shadows member inherited from type 'D3D12_BARRIER_SUBRESOURCE_RANGE' [-Wshadow-field] 
d3dx12.h(4121,14): warning : parameter 'NumPlanes' shadows member inherited from type 'D3D12_BARRIER_SUBRESOURCE_RANGE' [-Wshadow-field] 
```

