### PR TITLE
dxgicommon.idl: Make self-contained by `import`ing `ocidl.idl`

### DIFF
--- a/include/directx/dxgicommon.idl
+++ b/include/directx/dxgicommon.idl
@@ -3,6 +3,7 @@
 //    Licensed under the MIT license
 //
 
+import "ocidl.idl";
 
 typedef struct DXGI_RATIONAL
 {


### PR DESCRIPTION
dxgicommon.idl cannot be generated on its own because it uses `UINT` types without importing the necessary IDL file for this definition.
