### PR TITLE
Generate winmd bindings in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@ on:
 jobs:
   generate-winmd:
     name: Generate winmd
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
-      - uses: ilammy/msvc-dev-cmd@v1 # Needed to find CL.EXE
+      - name: Configure environment
+        shell: pwsh
+        run: |
+          "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x64" >> $env:GITHUB_PATH
+          ((Resolve-Path "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\*\bin\Hostx64\x64")
+            | Sort-Object -Descending | Select -First 1).ToString() >> $env:GITHUB_PATH
       - name: Generate
         run:  dotnet build
         working-directory: .metadata/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  generate-winmd:
+    name: Generate winmd
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ilammy/msvc-dev-cmd@v1 # Needed to find CL.EXE
+      - name: Generate
+        run:  dotnet build
+        working-directory: .metadata/
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: metadata
+          path: .windows/winmd

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 /out
 /CMakeUserPresets.json
 /build*
+/.metadata/obj
+/.metadata/bin

--- a/.metadata/d3d12.cpp
+++ b/.metadata/d3d12.cpp
@@ -1,0 +1,4 @@
+#include <d3d12.h>
+#include <d3d12sdklayers.h>
+#include <d3d12shader.h>
+#include <d3d12compatibility.h>

--- a/.metadata/d3d12.cpp
+++ b/.metadata/d3d12.cpp
@@ -1,4 +1,3 @@
 #include <d3d12.h>
-#include <d3d12sdklayers.h>
 #include <d3d12shader.h>
 #include <d3d12compatibility.h>

--- a/.metadata/d3dcommon.cpp
+++ b/.metadata/d3dcommon.cpp
@@ -1,0 +1,1 @@
+#include <d3dcommon.h>

--- a/.metadata/dxgicommon.cpp
+++ b/.metadata/dxgicommon.cpp
@@ -1,0 +1,2 @@
+#include <dxgicommon.h>
+#include <dxgiformat.h>

--- a/.metadata/emitter.settings.rsp
+++ b/.metadata/emitter.settings.rsp
@@ -1,6 +1,2 @@
 --memberRemap
 ^ID[2|3]D\w+$=[Agile]
---with-type
-D3D12_BARRIER_SYNC=uint
---with-type
-D3D12_BARRIER_ACCESS=uint

--- a/.metadata/emitter.settings.rsp
+++ b/.metadata/emitter.settings.rsp
@@ -1,2 +1,6 @@
 --memberRemap
 ^ID[2|3]D\w+$=[Agile]
+--with-type
+D3D12_BARRIER_SYNC=uint
+--with-type
+D3D12_BARRIER_ACCESS=uint

--- a/.metadata/emitter.settings.rsp
+++ b/.metadata/emitter.settings.rsp
@@ -1,0 +1,2 @@
+--memberRemap
+^ID[2|3]D\w+$=[Agile]

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Windows.WinmdGenerator/0.39.18-preview">
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.40.14-preview">
     <PropertyGroup Label="Globals">
         <OutputWinmd>../.windows/winmd/Windows.Win32.Graphics.Direct3D12.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.39.18-preview">
+    <PropertyGroup Label="Globals">
+        <OutputWinmd>../.windows/winmd/Windows.Win32.Graphics.Direct3D12.winmd</OutputWinmd>
+        <WinmdVersion>1.608.0</WinmdVersion>
+        <IdlDir>../include/directx</IdlDir>
+    </PropertyGroup>
+    <ItemGroup>
+        <Idls Include="$(IdlDir)/dxgicommon.idl;$(IdlDir)/dxgiformat.idl;$(IdlDir)/d3dcommon.idl;$(IdlDir)/d3d12.idl" />
+        <ManualCs Include="manual\*.cs"/>
+
+        <Partition Include="dxgicommon.cpp">
+            <TraverseFiles>$(CompiledHeadersDir)/dxgiformat.h;$(CompiledHeadersDir)/dxgicommon.h</TraverseFiles>
+            <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
+            <Namespace>Windows.Win32.Graphics.Dxgi.Common</Namespace>
+        </Partition>
+
+        <Partition Include="d3dcommon.cpp">
+            <TraverseFiles>$(CompiledHeadersDir)/d3dcommon.h</TraverseFiles>
+            <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
+            <Namespace>Windows.Win32.Graphics.Direct3D</Namespace>
+        </Partition>
+
+        <Partition Include="d3d12.cpp">
+            <TraverseFiles>$(CompiledHeadersDir)/d3d12.h</TraverseFiles>
+            <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
+            <Namespace>Windows.Win32.Graphics.Direct3D12</Namespace>
+        </Partition>
+    </ItemGroup>
+</Project>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Windows.WinmdGenerator/0.45.21-preview">
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.48.19-preview">
     <PropertyGroup Label="Globals">
         <OutputWinmd>../.windows/winmd/Microsoft.DirectX.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.Windows.WinmdGenerator/0.43.29-preview">
     <PropertyGroup Label="Globals">
-        <OutputWinmd>../.windows/winmd/Windows.Win32.Graphics.Direct3D12.winmd</OutputWinmd>
+        <OutputWinmd>../.windows/winmd/Microsoft.DirectX.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>
         <IdlDir>../include/directx</IdlDir>
     </PropertyGroup>
@@ -12,19 +12,28 @@
         <Partition Include="dxgicommon.cpp">
             <TraverseFiles>$(CompiledHeadersDir)/dxgiformat.h;$(CompiledHeadersDir)/dxgicommon.h</TraverseFiles>
             <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
-            <Namespace>Windows.Win32.Graphics.Dxgi.Common</Namespace>
+            <Namespace>Microsoft.DirectX.Dxgi.Common</Namespace>
         </Partition>
 
         <Partition Include="d3dcommon.cpp">
             <TraverseFiles>$(CompiledHeadersDir)/d3dcommon.h</TraverseFiles>
             <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
-            <Namespace>Windows.Win32.Graphics.Direct3D</Namespace>
+            <Namespace>Microsoft.DirectX.Direct3D</Namespace>
         </Partition>
 
         <Partition Include="d3d12.cpp">
             <TraverseFiles>$(CompiledHeadersDir)/d3d12.h;$(IdlDir)/d3d12sdklayers.h;$(CompiledHeadersDir)/d3d12compatibility.h;$(IdlDir)/d3d12shader.h</TraverseFiles>
             <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
-            <Namespace>Windows.Win32.Graphics.Direct3D12</Namespace>
+            <Namespace>Microsoft.DirectX.Direct3D12</Namespace>
         </Partition>
     </ItemGroup>
+    <Target Name="CopyWin32Metadata" AfterTargets="Build">
+        <Copy
+            SourceFiles="$(PkgMicrosoft_Windows_SDK_Win32Metadata)\Windows.Win32.winmd"
+            DestinationFiles="..\.windows\winmd\Windows.Win32.winmd" />
+
+        <Copy
+            SourceFiles="$(PkgMicrosoft_Windows_SDK_Win32Metadata)\Windows.Win32.Interop.dll"
+            DestinationFiles="..\.windows\winmd\Windows.Win32.Interop.winmd" />
+    </Target>
 </Project>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Windows.WinmdGenerator/0.40.14-preview">
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.42.39-preview">
     <PropertyGroup Label="Globals">
         <OutputWinmd>../.windows/winmd/Windows.Win32.Graphics.Direct3D12.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Windows.WinmdGenerator/0.43.29-preview">
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.44.17-preview">
     <PropertyGroup Label="Globals">
         <OutputWinmd>../.windows/winmd/Microsoft.DirectX.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -6,7 +6,7 @@
         <IdlDir>../include/directx</IdlDir>
     </PropertyGroup>
     <ItemGroup>
-        <Idls Include="$(IdlDir)/dxgicommon.idl;$(IdlDir)/dxgiformat.idl;$(IdlDir)/d3dcommon.idl;$(IdlDir)/d3d12.idl" />
+        <Idls Include="$(IdlDir)/dxgicommon.idl;$(IdlDir)/dxgiformat.idl;$(IdlDir)/d3dcommon.idl;$(IdlDir)/d3d12.idl;$(IdlDir)/d3d12compatibility.idl" />
         <ManualCs Include="manual\*.cs"/>
 
         <Partition Include="dxgicommon.cpp">
@@ -22,7 +22,7 @@
         </Partition>
 
         <Partition Include="d3d12.cpp">
-            <TraverseFiles>$(CompiledHeadersDir)/d3d12.h</TraverseFiles>
+            <TraverseFiles>$(CompiledHeadersDir)/d3d12.h;$(IdlDir)/d3d12sdklayers.h;$(CompiledHeadersDir)/d3d12compatibility.h;$(IdlDir)/d3d12shader.h</TraverseFiles>
             <ExcludeFromCrossarch>true</ExcludeFromCrossarch>
             <Namespace>Windows.Win32.Graphics.Direct3D12</Namespace>
         </Partition>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Windows.WinmdGenerator/0.42.39-preview">
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.43.29-preview">
     <PropertyGroup Label="Globals">
         <OutputWinmd>../.windows/winmd/Windows.Win32.Graphics.Direct3D12.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>

--- a/.metadata/generate.proj
+++ b/.metadata/generate.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.Windows.WinmdGenerator/0.44.17-preview">
+<Project Sdk="Microsoft.Windows.WinmdGenerator/0.45.21-preview">
     <PropertyGroup Label="Globals">
         <OutputWinmd>../.windows/winmd/Microsoft.DirectX.winmd</OutputWinmd>
         <WinmdVersion>1.608.0</WinmdVersion>

--- a/.metadata/libMappsings.rsp
+++ b/.metadata/libMappsings.rsp
@@ -1,0 +1,16 @@
+--with-librarypath
+D3D12SerializeVersionedRootSignature=d3d12.dll
+D3D12SerializeRootSignature=d3d12.dll
+D3D12PIXReportCounter=d3d12.dll
+D3D12PIXNotifyWakeFromFenceSignal=d3d12.dll
+D3D12PIXGetThreadInfo=d3d12.dll
+D3D12PIXEventsReplaceBlock=d3d12.dll
+D3D12GetInterface=d3d12.dll
+D3D12GetDebugInterface=d3d12.dll
+D3D12EnableExperimentalFeatures=d3d12.dll
+D3D12CreateVersionedRootSignatureDeserializer=d3d12.dll
+D3D12CreateRootSignatureDeserializer=d3d12.dll
+D3D12CreateDevice=d3d12.dll
+D3D12CoreRegisterLayers=d3d12.dll
+D3D12CoreGetLayeredDeviceSize=d3d12.dll
+D3D12CoreCreateLayeredDevice=d3d12.dll

--- a/.metadata/manual/Direct3D12.cs
+++ b/.metadata/manual/Direct3D12.cs
@@ -1,0 +1,12 @@
+// Ported from um/d3d12.h in the Windows SDK for Windows 10.0.19041.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace Microsoft.DirectX.Direct3D12
+{
+    public static unsafe partial class Apis
+    {
+        public const uint D3D12_SHADER_COMPONENT_MAPPING_ALWAYS_SET_BIT_AVOIDING_ZEROMEM_MISTAKES = 1 << (unchecked((int)D3D12_SHADER_COMPONENT_MAPPING_SHIFT) * 4);
+
+        public const uint D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING = 0x1688;
+    }
+}

--- a/include/directx/d3d12.idl
+++ b/include/directx/d3d12.idl
@@ -5432,9 +5432,7 @@ typedef enum D3D12_BARRIER_SYNC
     D3D12_BARRIER_SYNC_VIDEO_ENCODE                                             = 0x400000,
     D3D12_BARRIER_SYNC_BUILD_RAYTRACING_ACCELERATION_STRUCTURE                  = 0x800000,
     D3D12_BARRIER_SYNC_COPY_RAYTRACING_ACCELERATION_STRUCTURE                   = 0x1000000,
-    // error CS0031: Constant value '-2147483648' cannot be converted to a 'uint' 
-    // D3D12_BARRIER_SYNC_SPLIT = unchecked((int)(0x80000000)),
-    // D3D12_BARRIER_SYNC_SPLIT                                                    = 0x80000000,
+    D3D12_BARRIER_SYNC_SPLIT                                                    = 0x80000000,
 } D3D12_BARRIER_SYNC;
 cpp_quote( "DEFINE_ENUM_FLAG_OPERATORS( D3D12_BARRIER_SYNC );" )
 
@@ -5465,7 +5463,7 @@ typedef enum D3D12_BARRIER_ACCESS
     D3D12_BARRIER_ACCESS_VIDEO_PROCESS_WRITE                        = 0x100000,
     D3D12_BARRIER_ACCESS_VIDEO_ENCODE_READ                          = 0x200000,
     D3D12_BARRIER_ACCESS_VIDEO_ENCODE_WRITE                         = 0x400000,
-    // D3D12_BARRIER_ACCESS_NO_ACCESS                                  = 0x80000000,
+    D3D12_BARRIER_ACCESS_NO_ACCESS                                  = 0x80000000,
 } D3D12_BARRIER_ACCESS;
 cpp_quote( "DEFINE_ENUM_FLAG_OPERATORS( D3D12_BARRIER_ACCESS );" )
 

--- a/include/directx/d3d12.idl
+++ b/include/directx/d3d12.idl
@@ -5432,7 +5432,9 @@ typedef enum D3D12_BARRIER_SYNC
     D3D12_BARRIER_SYNC_VIDEO_ENCODE                                             = 0x400000,
     D3D12_BARRIER_SYNC_BUILD_RAYTRACING_ACCELERATION_STRUCTURE                  = 0x800000,
     D3D12_BARRIER_SYNC_COPY_RAYTRACING_ACCELERATION_STRUCTURE                   = 0x1000000,
-    D3D12_BARRIER_SYNC_SPLIT                                                    = 0x80000000,
+    // error CS0031: Constant value '-2147483648' cannot be converted to a 'uint' 
+    // D3D12_BARRIER_SYNC_SPLIT = unchecked((int)(0x80000000)),
+    // D3D12_BARRIER_SYNC_SPLIT                                                    = 0x80000000,
 } D3D12_BARRIER_SYNC;
 cpp_quote( "DEFINE_ENUM_FLAG_OPERATORS( D3D12_BARRIER_SYNC );" )
 
@@ -5463,7 +5465,7 @@ typedef enum D3D12_BARRIER_ACCESS
     D3D12_BARRIER_ACCESS_VIDEO_PROCESS_WRITE                        = 0x100000,
     D3D12_BARRIER_ACCESS_VIDEO_ENCODE_READ                          = 0x200000,
     D3D12_BARRIER_ACCESS_VIDEO_ENCODE_WRITE                         = 0x400000,
-    D3D12_BARRIER_ACCESS_NO_ACCESS                                  = 0x80000000,
+    // D3D12_BARRIER_ACCESS_NO_ACCESS                                  = 0x80000000,
 } D3D12_BARRIER_ACCESS;
 cpp_quote( "DEFINE_ENUM_FLAG_OPERATORS( D3D12_BARRIER_ACCESS );" )
 


### PR DESCRIPTION
Depends on #81
Fixes #79 

After (re?)discovering @riverar's https://github.com/riverar/washington-rs sample I was both intrigued and inspired to see how easy it would be to generate a `.winmd` file for DirectX headers, fixing #79.  At the same time I prefer to automate this in GitHub actions for easy and direct access to metadata after changes, which ended up super trivial to implement.
At the same time I primarily use Linux where `WinmdGenerator` doesn't really work (starting with lots of capitalization discrepancies around `sdk/sdk.{props,targets}`), having direct access to an automated Windows CI is valuable.

Note that these bindings are generated from IDL (which `Microsoft.Windows.WinmdGenerator` converts to `*.h` first) instead of the `*.h` files checked in to the repo, as that only got me constants but not `interface`s.

### Bugs to fix

- `d3d12.cpp` fails to generate because of missing `DXGI_FORMAT` type, unless I add the DXGI compiled headers to `TraverseFiles`: but this causes the type to also appear under that namespace;
  - I could `<Exclude>` the type, but then:
  - Somehow the various partitions should be able to cross-reference each-other; but [none of the official `GeneratorSdk` samples](https://github.com/microsoft/win32metadata/tree/main/sources/GeneratorSdk/samples) seem to cover this.
- `D3D12_BARRIER_SYNC_SPLIT` / `D3D12_BARRIER_ACCESS_NO_ACCESS` use `0x80000000` which result in an odd cast: `D3D12_BARRIER_SYNC_SPLIT = unchecked((int)(0x80000000))`, that's rejected by the C# compiler: `error CS0031: Constant value '-2147483648' cannot be converted to a 'uint'`.

### Things to discuss

- Should we check in `.winmd` to the repo, similar to how `Direct3D Build Agent` currently updates the repo, or only leave this file available as artifact in GitHub actions, or something else entirely?
- Where to host the Rust code, once the bugs above are solved and my in-progress generator (based on @riverar's `washington-rs`) gets cleaned up?  Looks like @kennykerr already preempted this and squatted the crate name I wished to use for it yesterday: https://crates.io/crates/windows-directx;
  - I'll submit my (in-progress) bindings wherever you want it!
