### PR TITLE
Fix WSL build break due to use of legacy NULL macro

### DIFF
--- a/include/directx/d3dx12_property_format_table.h
+++ b/include/directx/d3dx12_property_format_table.h
@@ -110,7 +110,7 @@ public:
     static HRESULT                              CalculateResourceSize               (UINT width, UINT height, UINT depth, DXGI_FORMAT format, UINT mipLevels, UINT subresources, _Out_ SIZE_T& totalByteSize, _Out_writes_opt_(subresources) D3D12_MEMCPY_DEST* pDst = nullptr);
     static void                                 GetTileShape                        (D3D12_TILE_SHAPE* pTileShape, DXGI_FORMAT Format, D3D12_RESOURCE_DIMENSION Dimension, UINT SampleCount);
     static void                                 Get4KTileShape                      (D3D12_TILE_SHAPE* pTileShape, DXGI_FORMAT Format, D3D12_RESOURCE_DIMENSION Dimension, UINT SampleCount);
-    static void                                 GetMipDimensions                    (UINT8 mipSlice, _Inout_ UINT64* pWidth, _Inout_opt_ UINT64* pHeight = NULL, _Inout_opt_ UINT64* pDepth = NULL);
+    static void                                 GetMipDimensions                    (UINT8 mipSlice, _Inout_ UINT64* pWidth, _Inout_opt_ UINT64* pHeight = nullptr, _Inout_opt_ UINT64* pDepth = nullptr);
     static void                                 GetPlaneSubsampledSizeAndFormatForCopyableLayout(UINT PlaneSlice, DXGI_FORMAT Format, UINT Width, UINT Height, _Out_ DXGI_FORMAT& PlaneFormat, _Out_ UINT& MinPlanePitchWidth, _Out_ UINT& PlaneWidth, _Out_ UINT& PlaneHeight);
 
     static UINT                                 GetDetailTableIndex         (DXGI_FORMAT  Format);

--- a/src/d3dx12_property_format_table.cpp
+++ b/src/d3dx12_property_format_table.cpp
@@ -1007,7 +1007,7 @@ HRESULT D3D12_PROPERTY_LAYOUT_FORMAT_TABLE::CalculateResourceSize(
 
             // This data will be returned straight from the API to satisfy Map. So, strides/ alignment must be API-correct.
             dst.pData = reinterpret_cast<void*>(totalByteSize);
-            assert(s != 0 || dst.pData == NULL);
+            assert(s != 0 || dst.pData == nullptr);
 
             dst.RowPitch = rowPitch; 
             dst.SlicePitch = depthPitch;
@@ -1212,7 +1212,7 @@ const D3D12_PROPERTY_LAYOUT_FORMAT_TABLE::FORMAT_DETAIL* D3D12_PROPERTY_LAYOUT_F
     const UINT Index = GetDetailTableIndex(Format);
     if( -1 == Index )
     {
-        return NULL;
+        return nullptr;
     }
   
   return &s_FormatDetail[ Index ];


### PR DESCRIPTION
The property table class was making use of the legacy C macro ``NULL`` instead of the C++11 language symbol ``nullptr``. While these mean the same thing in most contexts, the C version depends on a specific standard header being included while the C++11 does not (as well as being better supported for type-safety and warnings). In the case of DirectXTex on WSL, this macro usage resulted in build breaks.

Note that C23 supports ``nullptr``. The code in this header already requires C++ and does not need C compatibility in any case.

> These were the only instances in the repository using legacy ``NULL`` other than comments.
