### PR TITLE
Fix SAL annotation for CD3DX12_RESOURCE_BARRIER::UAV

### DIFF
--- a/include/directx/d3dx12_barriers.h
+++ b/include/directx/d3dx12_barriers.h
@@ -48,7 +48,7 @@ struct CD3DX12_RESOURCE_BARRIER : public D3D12_RESOURCE_BARRIER
         return result;
     }
     static inline CD3DX12_RESOURCE_BARRIER UAV(
-        _In_ ID3D12Resource* pResource) noexcept
+        _In_opt_ ID3D12Resource* pResource) noexcept
     {
         CD3DX12_RESOURCE_BARRIER result = {};
         D3D12_RESOURCE_BARRIER &barrier = result;


### PR DESCRIPTION
NULL resources in UAV barriers are legal, so the SAL annotation should permit nullptr as an argument. See https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ns-d3d12-d3d12_resource_uav_barrier#remarks