### PR TITLE
Improvements to CMake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(DirectX-Headers
 set(CMAKE_CXX_STANDARD 14) 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+enable_testing()
 
 # It's useful to know if you are a top level project or not, if your project is
 # being consumed via add_subdirectory
@@ -103,10 +104,14 @@ if (DXHEADERS_INSTALL)
     
 endif()
 
-if (DXHEADERS_BUILD_TEST)
-    add_subdirectory(test) 
-endif()
+if (BUILD_TESTING)
+    if (DXHEADERS_BUILD_TEST)
+       add_subdirectory(test) 
+    endif()
 
-if (DXHEADERS_BUILD_GOOGLE_TEST)
-    add_subdirectory(googletest)
+    if (DXHEADERS_BUILD_GOOGLE_TEST)
+       # We do not want to install GoogleTest when packaging DirectX-Headers.
+       set(INSTALL_GTEST OFF)
+       add_subdirectory(googletest)
+    endif()
 endif()

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(Feature-Support-Test feature_support_test.cpp)
 target_link_libraries(Feature-Support-Test DirectX-Headers DirectX-Guids ${dxlibs} gtest_main)
+add_test(Feature-Support-Test Feature-Support-Test)
 
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
     target_compile_options(Feature-Support-Test PRIVATE -Wno-unused-variable)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,8 +28,9 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(TEST_EXES DirectX-Headers-Test DirectX-Headers-Check-Feature-Support-Test)
 
 add_executable(DirectX-Headers-Test test.cpp)
-
+add_test(NAME DirectX-Headers-Test COMMAND DirectX-Headers-Test)
 add_executable(DirectX-Headers-Check-Feature-Support-Test feature_check_test.cpp)
+add_test(NAME DirectX-Headers-Check-Feature-Support-Test COMMAND DirectX-Headers-Check-Feature-Support-Test)
 
 foreach(t IN LISTS TEST_EXES)
   target_link_libraries(${t} DirectX-Headers DirectX-Guids ${dxlibs})


### PR DESCRIPTION
1.  Do NOT install the GoogleTest files (run-time files, pkg-config files, static-link-libraries, etc.) when installing DirectX-Headers.  MSYS2 and many Linux distributions already have GoogleTest in downloadable packages.
2. Run the included tests with CTest (see: https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html ) to facilitate automated testing in package build processes.  This adds a BUILD_TESTING option that is standard for many CMake projects.  If that option is off, no tests are built or could be executing using CTest (a standard behavior).