### PR TITLE
Improvements to meson build primarily for testing

### DIFF
--- a/googletest/meson.build
+++ b/googletest/meson.build
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+gtest = cpp.find_library('gtest', required: false)
+gtest_main = cpp.find_library('gtest_main', required: false)
+
+if gtest.found() and gtest_main.found()
+  feature_support_test = executable('Feature-Support-Test', 'feature_support_test.cpp',
+    dependencies : [gtest, gtest_main, dep_dxheaders, d3d12_lib, dxcore_lib],
+    cpp_args : test_compile_opts,
+    c_args : test_compile_opts)
+  test('Feature-Support-Test', feature_support_test)
+endif

--- a/meson.build
+++ b/meson.build
@@ -42,6 +42,7 @@ endif
 pkg = import('pkgconfig')
 pkg.generate(name : 'DirectX-Headers',
              description : 'Headers for using D3D12',
+             url: 'https://github.com/microsoft/DirectX-Headers',
              libraries : [format_properties_lib, guids_lib],
              version : meson.project_version(),
              subdirs : install_inc_subdirs)

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,23 @@
 project('DirectX-Headers', 'cpp', version : '1.610.0',
         default_options : ['cpp_std=c++14'])
 
+cpp = meson.get_compiler('cpp')
+compiler_id = cpp.get_id()
+d3d12_lib = cpp.find_library('d3d12')
+#dxcore is not available in Mingw-w64
+if compiler_id == 'msvc'
+    dxcore_lib = cpp.find_library('dxcore')
+else
+    dxcore_lib = cpp.find_library('dxcore', required: false)
+endif
+test_compile_opts = []
+if host_machine.system() == 'windows'
+    test_compile_opts = ['-DUNICODE', '-D_WIN32_WINNT=0x0A00']
+endif
+if (compiler_id == 'gcc') or (compiler_id == 'clang')
+    test_compile_opts += ['-Wno-unused-variable']
+endif
+
 inc_dirs = [include_directories('include', is_system : true)]
 install_inc_subdirs = ['']
 compile_options = []
@@ -36,6 +53,7 @@ if meson.version().version_compare('>=0.54.0')
 endif
 
 if not meson.is_subproject() and get_option('build-test')
+    subdir('googletest')
     subdir('test')
 endif
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -26,7 +26,7 @@ headers_test = executable('DirectX-Headers-Test', 'test.cpp',
     dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib],
     cpp_args : t_compile_opts,
     c_args : t_compile_opts)
-test('DirectX-Headers-Testz', headers_test)
+test('DirectX-Headers-Test', headers_test)
 
 headers_features_test = executable('DirectX-Headers-Check-Feature-Support-Test', 'feature_check_test.cpp',
     dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib],

--- a/test/meson.build
+++ b/test/meson.build
@@ -3,7 +3,34 @@
 
 cpp = meson.get_compiler('cpp')
 d3d12_lib = cpp.find_library('d3d12')
-dxcore_lib = cpp.find_library('dxcore')
+
+compiler_id = cpp.get_id()
+
+#dxcore is not available in Mingw-w64
+if compiler_id == 'msvc'
+  dxcore_lib = cpp.find_library('dxcore')
+else
+  dxcore_lib = cpp.find_library('dxcore', required: false)
+endif
+
+t_compile_opts = []
+if host_machine.system() == 'windows'
+  t_compile_opts = ['-DUNICODE', '-D_WIN32_WINNT=0x0A00']
+endif
+
+if (compiler_id == 'gcc') or (compiler_id == 'clang')
+  t_compile_opts += ['-Wno-unused-variable']
+endif
 
 headers_test = executable('DirectX-Headers-Test', 'test.cpp',
-    dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib])
+    dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib],
+    cpp_args : t_compile_opts,
+    c_args : t_compile_opts)
+test('DirectX-Headers-Testz', headers_test)
+
+headers_features_test = executable('DirectX-Headers-Check-Feature-Support-Test', 'feature_check_test.cpp',
+    dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib],
+    cpp_args : t_compile_opts,
+    c_args : t_compile_opts)
+test('DirectX-Headers-Check-Feature-Support-Test', headers_features_test)
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,36 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-cpp = meson.get_compiler('cpp')
-d3d12_lib = cpp.find_library('d3d12')
-
-compiler_id = cpp.get_id()
-
-#dxcore is not available in Mingw-w64
-if compiler_id == 'msvc'
-  dxcore_lib = cpp.find_library('dxcore')
-else
-  dxcore_lib = cpp.find_library('dxcore', required: false)
-endif
-
-t_compile_opts = []
-if host_machine.system() == 'windows'
-  t_compile_opts = ['-DUNICODE', '-D_WIN32_WINNT=0x0A00']
-endif
-
-if (compiler_id == 'gcc') or (compiler_id == 'clang')
-  t_compile_opts += ['-Wno-unused-variable']
-endif
-
 headers_test = executable('DirectX-Headers-Test', 'test.cpp',
     dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib],
-    cpp_args : t_compile_opts,
-    c_args : t_compile_opts)
+    cpp_args : test_compile_opts,
+    c_args : test_compile_opts)
 test('DirectX-Headers-Test', headers_test)
 
 headers_features_test = executable('DirectX-Headers-Check-Feature-Support-Test', 'feature_check_test.cpp',
     dependencies : [dep_dxheaders, d3d12_lib, dxcore_lib],
-    cpp_args : t_compile_opts,
-    c_args : t_compile_opts)
+    cpp_args : test_compile_opts,
+    c_args : test_compile_opts)
 test('DirectX-Headers-Check-Feature-Support-Test', headers_features_test)
 


### PR DESCRIPTION
1. Minor fix - add URL to pkg-config file
2. When building tests, make dxcore optional if not using "msvc"
3. programs in test directory now build even on Windows.
4. Compile DirectX-Headers-Check-Feature-Support-Test.exe if tests are on
5. Use test() statements to add DirectX-Headers-Test.exe and DirectX-Headers-Check-Feature-Support-Test.exe to "test" build target (typically invoked with something like "ninja test" or "make test".