### PR TITLE
Fix clang warning in renderpass D3DX12 header

### DIFF
--- a/include/directx/d3dx12_render_pass.h
+++ b/include/directx/d3dx12_render_pass.h
@@ -45,6 +45,17 @@ inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS
     return true;
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4062)
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wswitch"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12_RENDER_PASS_BEGINNING_ACCESS &b) noexcept
 {
     if (a.Type != b.Type) return false;
@@ -60,8 +71,6 @@ inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12
         if (!(a.PreserveLocal == b.PreserveLocal)) return false;
         break;
 #endif
-    default:
-        break;
     }
     return true;
 }
@@ -81,12 +90,18 @@ inline bool operator==(const D3D12_RENDER_PASS_ENDING_ACCESS& a, const D3D12_REN
         if (!(a.PreserveLocal == b.PreserveLocal)) return false;
         break;
 #endif
-    default:
-        break;
     }
 
     return true;
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 inline bool operator==( const D3D12_RENDER_PASS_RENDER_TARGET_DESC &a, const D3D12_RENDER_PASS_RENDER_TARGET_DESC &b) noexcept
 {

--- a/include/directx/d3dx12_render_pass.h
+++ b/include/directx/d3dx12_render_pass.h
@@ -34,6 +34,11 @@ inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETER
     return a.ClearValue == b.ClearValue;
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcovered-switch-default"
+#endif
+
 inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &a, const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &b) noexcept
 {
     if (a.pSrcResource != b.pSrcResource) return false;
@@ -60,6 +65,8 @@ inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12
         if (!(a.PreserveLocal == b.PreserveLocal)) return false;
         break;
 #endif
+    default:
+        break;
     }
     return true;
 }
@@ -79,10 +86,16 @@ inline bool operator==(const D3D12_RENDER_PASS_ENDING_ACCESS& a, const D3D12_REN
         if (!(a.PreserveLocal == b.PreserveLocal)) return false;
         break;
 #endif
+    default:
+        break;
     }
 
     return true;
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 inline bool operator==( const D3D12_RENDER_PASS_RENDER_TARGET_DESC &a, const D3D12_RENDER_PASS_RENDER_TARGET_DESC &b) noexcept
 {

--- a/include/directx/d3dx12_render_pass.h
+++ b/include/directx/d3dx12_render_pass.h
@@ -34,11 +34,6 @@ inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS_CLEAR_PARAMETER
     return a.ClearValue == b.ClearValue;
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcovered-switch-default"
-#endif
-
 inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &a, const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS &b) noexcept
 {
     if (a.pSrcResource != b.pSrcResource) return false;
@@ -92,10 +87,6 @@ inline bool operator==(const D3D12_RENDER_PASS_ENDING_ACCESS& a, const D3D12_REN
 
     return true;
 }
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 inline bool operator==( const D3D12_RENDER_PASS_RENDER_TARGET_DESC &a, const D3D12_RENDER_PASS_RENDER_TARGET_DESC &b) noexcept
 {

--- a/include/directx/d3dx12_render_pass.h
+++ b/include/directx/d3dx12_render_pass.h
@@ -45,17 +45,6 @@ inline bool operator==( const D3D12_RENDER_PASS_ENDING_ACCESS_RESOLVE_PARAMETERS
     return true;
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4062)
-#endif
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-#pragma GCC diagnostic ignored "-Wswitch-default"
-#endif
-
 inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12_RENDER_PASS_BEGINNING_ACCESS &b) noexcept
 {
     if (a.Type != b.Type) return false;
@@ -71,6 +60,8 @@ inline bool operator==( const D3D12_RENDER_PASS_BEGINNING_ACCESS &a, const D3D12
         if (!(a.PreserveLocal == b.PreserveLocal)) return false;
         break;
 #endif
+    default:
+        break;
     }
     return true;
 }
@@ -90,18 +81,11 @@ inline bool operator==(const D3D12_RENDER_PASS_ENDING_ACCESS& a, const D3D12_REN
         if (!(a.PreserveLocal == b.PreserveLocal)) return false;
         break;
 #endif
+    default:
+        break;
     }
-
     return true;
 }
-
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 inline bool operator==( const D3D12_RENDER_PASS_RENDER_TARGET_DESC &a, const D3D12_RENDER_PASS_RENDER_TARGET_DESC &b) noexcept
 {


### PR DESCRIPTION
Fixes these warnings that happens with this D3DX12 header with clang/LLVM:

```
Microsoft.Direct3D.D3D12.1.613.3\build\native\include\d3dx12/d3dx12_render_pass.h(51,13): warning : enumeration values 'D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_DISCARD', 'D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_PRESERVE', and 'D3D12_RENDER_PASS_BEGINNING_ACCESS_TYPE_NO_ACCESS' not handled in switch [-Wswitch] 

Microsoft.Direct3D.D3D12.1.613.3\build\native\include\d3dx12/d3dx12_render_pass.h(70,13): warning : enumeration values 'D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_DISCARD', 'D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_PRESERVE', and 'D3D12_RENDER_PASS_ENDING_ACCESS_TYPE_NO_ACCESS' not handled in switch [-Wswitch]
```