### PR TITLE
Exposing some hidden CFunctionReflection members to the front end (ID3D12LibraryReflection/ID3D12FunctionReflection)

### DIFF
--- a/include/directx/d3d12shader.h
+++ b/include/directx/d3d12shader.h
@@ -208,7 +208,6 @@ typedef struct _D3D12_SHADER_INPUT_BIND_DESC
 #define D3D_SHADER_REQUIRES_SAMPLE_CMP_GRADIENT_OR_BIAS                                     0x80000000
 #define D3D_SHADER_REQUIRES_EXTENDED_COMMAND_INFO                                           0x100000000ull
 
-
 typedef struct _D3D12_LIBRARY_DESC
 {
     LPCSTR    Creator;           // The name of the originator of the library.
@@ -216,44 +215,122 @@ typedef struct _D3D12_LIBRARY_DESC
     UINT      FunctionCount;     // Number of functions exported from the library.
 } D3D12_LIBRARY_DESC;
 
+typedef struct _D3D12_FUNCTION_COMPUTE_DESC {
+    UINT                                    WaveSizeMin;                  // SM 6.8+ WaveSize(n, ..., ...) min, max, pref
+    UINT                                    WaveSizeMax;                  // SM 6.8+ WaveSize(..., n, ...) min, max, pref
+    UINT                                    WaveSizePreferred;            // SM 6.6 WaveSize(n) or WaveSize(.., ..., n)
+    UINT                                    NumThreads[3];                // numthreads(x, y, z)
+} D3D12_FUNCTION_COMPUTE_DESC;
+
+typedef struct _D3D12_FUNCTION_NODE_DESC {
+    D3D12_FUNCTION_COMPUTE_DESC             ComputeDesc;                  // Node extends ComputeDesc
+    D3D12_NODE_OVERRIDES_TYPE               LaunchType;                   // Launch type
+    BOOL                                    IsProgramEntry;               // Is program entry
+    INT                                     LocalRootArgumentsTableIndex; // Local root arguments table index
+    UINT                                    DispatchGrid[3];              // Dispatch grid
+    UINT                                    MaxDispatchGrid[3];           // Max dispatch grid
+    UINT                                    MaxRecursionDepth;            // Max recursion depth
+} D3D12_FUNCTION_NODE_DESC;
+
+typedef struct _D3D12_FUNCTION_RAYTRACING_DESC {
+    UINT                                    ParamPayloadSize;             // Payload or param size (callable) in bytes
+    UINT                                    AttributeSize;                // Attribute size in bytes
+} D3D12_FUNCTION_RAYTRACING_DESC;
+
+typedef struct _D3D12_FUNCTION_AMPLIFICATION_DESC {
+    UINT                                    PayloadSize;                  // Payload size in bytes
+} D3D12_FUNCTION_AMPLIFICATION_DESC;
+
+typedef struct _D3D12_FUNCTION_PIXEL_DESC {
+    BOOL                                    EarlyDepthStencil;            // Early depth stencil
+} D3D12_FUNCTION_PIXEL_DESC;
+
+typedef struct _D3D12_FUNCTION_DOMAIN_DESC {
+    D3D12_TESSELLATOR_DOMAIN                Domain;                       // Domain
+    UINT                                    InputControlPoints;           // Input control points
+} D3D12_FUNCTION_DOMAIN_DESC;
+
+typedef struct _D3D12_FUNCTION_HULL_DESC {
+    D3D12_TESSELLATOR_DOMAIN                Domain;                       // Domain
+    D3D12_TESSELLATOR_PARTITIONING          Partition;                    // Partition
+    D3D12_TESSELLATOR_OUTPUT_PRIMITIVE      OutputPrimitive;              // Output primitive
+    UINT                                    InputControlPoints;           // Input control points
+    UINT                                    OutputControlPoints;          // Output control points
+    FLOAT                                   MaxTessFactor;                // Max tessellation factor
+} D3D12_FUNCTION_HULL_DESC;
+
+typedef struct _D3D12_FUNCTION_GEOMETRY_DESC {
+    D3D12_PRIMITIVE                         InputPrimitive;               // Input primitive
+    UINT                                    MaxVertexCount;               // Max vertex count
+    UINT                                    InstanceCount;                // Instance count
+    D3D12_PRIMITIVE_TOPOLOGY                StreamPrimitiveTopologies[4]; // Stream primitive topologies
+} D3D12_FUNCTION_GEOMETRY_DESC;
+
+typedef enum D3D12_MESH_OUTPUT_TOPOLOGY {
+  D3D12_MESH_OUTPUT_TOPOLOGY_LINE = 1,
+  D3D12_MESH_OUTPUT_TOPOLOGY_TRIANGLE = 2
+} D3D12_MESH_OUTPUT_TOPOLOGY;
+
+typedef struct _D3D12_FUNCTION_MESH_DESC {
+    UINT                                    PayloadSize;                  // Payload size in bytes
+    UINT                                    MaxVertexCount;               // Max vertex count
+    UINT                                    MaxPrimitiveCount;            // Max primitive count
+    D3D12_MESH_OUTPUT_TOPOLOGY              OutputTopology;               // Output topology
+} D3D12_FUNCTION_MESH_DESC;
+
 typedef struct _D3D12_FUNCTION_DESC
 {
-    UINT                    Version;                     // Shader version
-    LPCSTR                  Creator;                     // Creator string
-    UINT                    Flags;                       // Shader compilation/parse flags
-    
-    UINT                    ConstantBuffers;             // Number of constant buffers
-    UINT                    BoundResources;              // Number of bound resources
+    UINT                                    Version;                      // Shader version
+    LPCSTR                                  Creator;                      // Creator string
+    UINT                                    Flags;                        // Shader compilation/parse flags
 
-    UINT                    InstructionCount;            // Number of emitted instructions
-    UINT                    TempRegisterCount;           // Number of temporary registers used 
-    UINT                    TempArrayCount;              // Number of temporary arrays used
-    UINT                    DefCount;                    // Number of constant defines 
-    UINT                    DclCount;                    // Number of declarations (input + output)
-    UINT                    TextureNormalInstructions;   // Number of non-categorized texture instructions
-    UINT                    TextureLoadInstructions;     // Number of texture load instructions
-    UINT                    TextureCompInstructions;     // Number of texture comparison instructions
-    UINT                    TextureBiasInstructions;     // Number of texture bias instructions
-    UINT                    TextureGradientInstructions; // Number of texture gradient instructions
-    UINT                    FloatInstructionCount;       // Number of floating point arithmetic instructions used
-    UINT                    IntInstructionCount;         // Number of signed integer arithmetic instructions used
-    UINT                    UintInstructionCount;        // Number of unsigned integer arithmetic instructions used
-    UINT                    StaticFlowControlCount;      // Number of static flow control instructions used
-    UINT                    DynamicFlowControlCount;     // Number of dynamic flow control instructions used
-    UINT                    MacroInstructionCount;       // Number of macro instructions used
-    UINT                    ArrayInstructionCount;       // Number of array instructions used
-    UINT                    MovInstructionCount;         // Number of mov instructions used
-    UINT                    MovcInstructionCount;        // Number of movc instructions used
-    UINT                    ConversionInstructionCount;  // Number of type conversion instructions used
-    UINT                    BitwiseInstructionCount;     // Number of bitwise arithmetic instructions used
-    D3D_FEATURE_LEVEL       MinFeatureLevel;             // Min target of the function byte code
-    UINT64                  RequiredFeatureFlags;        // Required feature flags
+    UINT                                    ConstantBuffers;              // Number of constant buffers
+    UINT                                    BoundResources;               // Number of bound resources
 
-    LPCSTR                  Name;                        // Function name
-    INT                     FunctionParameterCount;      // Number of logical parameters in the function signature (not including return)
-    BOOL                    HasReturn;                   // TRUE, if function returns a value, false - it is a subroutine
-    BOOL                    Has10Level9VertexShader;     // TRUE, if there is a 10L9 VS blob
-    BOOL                    Has10Level9PixelShader;      // TRUE, if there is a 10L9 PS blob
+    UINT                                    InstructionCount;             // Number of emitted instructions
+    UINT                                    TempRegisterCount;            // Number of temporary registers used 
+    UINT                                    TempArrayCount;               // Number of temporary arrays used
+    UINT                                    DefCount;                     // Number of constant defines 
+    UINT                                    DclCount;                     // Number of declarations (input + output)
+    UINT                                    TextureNormalInstructions;    // Number of non-categorized texture instructions
+    UINT                                    TextureLoadInstructions;      // Number of texture load instructions
+    UINT                                    TextureCompInstructions;      // Number of texture comparison instructions
+    UINT                                    TextureBiasInstructions;      // Number of texture bias instructions
+    UINT                                    TextureGradientInstructions;  // Number of texture gradient instructions
+    UINT                                    FloatInstructionCount;        // Number of floating point arithmetic instructions used
+    UINT                                    IntInstructionCount;          // Number of signed integer arithmetic instructions used
+    UINT                                    UintInstructionCount;         // Number of unsigned integer arithmetic instructions used
+    UINT                                    StaticFlowControlCount;       // Number of static flow control instructions used
+    UINT                                    DynamicFlowControlCount;      // Number of dynamic flow control instructions used
+    UINT                                    MacroInstructionCount;        // Number of macro instructions used
+    UINT                                    ArrayInstructionCount;        // Number of array instructions used
+    UINT                                    MovInstructionCount;          // Number of mov instructions used
+    UINT                                    MovcInstructionCount;         // Number of movc instructions used
+    UINT                                    ConversionInstructionCount;   // Number of type conversion instructions used
+    UINT                                    BitwiseInstructionCount;      // Number of bitwise arithmetic instructions used
+    D3D_FEATURE_LEVEL                       MinFeatureLevel;              // Min target of the function byte code
+    UINT64                                  RequiredFeatureFlags;         // Required feature flags
+
+    LPCSTR                                  Name;                         // Function name
+    INT                                     FunctionParameterCount;       // Number of logical parameters in the function signature (not including return)
+    BOOL                                    HasReturn;                    // TRUE, if function returns a value, false - it is a subroutine
+    BOOL                                    Has10Level9VertexShader;      // TRUE, if there is a 10L9 VS blob
+    BOOL                                    Has10Level9PixelShader;       // TRUE, if there is a 10L9 PS blob
+
+    D3D12_SHADER_VERSION_TYPE               ShaderType;                   // Function's shader stage
+
+    union {
+        D3D12_FUNCTION_NODE_DESC            NodeShader;                   // ShaderType == D3D12_SHVER_NODE_SHADER
+        D3D12_FUNCTION_HULL_DESC            HullShader;                   // ShaderType == D3D12_SHVER_HULL_SHADER
+        D3D12_FUNCTION_COMPUTE_DESC         ComputeShader;                // ShaderType == D3D12_SHVER_COMPUTE_SHADER
+        D3D12_FUNCTION_MESH_DESC            MeshShader;                   // ShaderType == D3D12_SHVER_MESH_SHADER
+        D3D12_FUNCTION_GEOMETRY_DESC        GeometryShader;               // ShaderType == D3D12_SHVER_GEOMETRY_SHADER
+        D3D12_FUNCTION_RAYTRACING_DESC      RaytracingShader;             // ShaderType > D3D12_SHVER_RAY_GENERATION_SHADER && <= D3D12_SHVER_CALLABLE_SHADER
+        D3D12_FUNCTION_DOMAIN_DESC          DomainShader;                 // ShaderType == D3D12_SHVER_DOMAIN_SHADER
+        D3D12_FUNCTION_AMPLIFICATION_DESC   AmplificationShader;          // ShaderType == D3D12_SHVER_AMPLIFICATION_SHADER
+        D3D12_FUNCTION_PIXEL_DESC           PixelShader;                  // ShaderType == D3D12_SHVER_PIXEL_SHADER
+    };
+
 } D3D12_FUNCTION_DESC;
 
 typedef struct _D3D12_PARAMETER_DESC

--- a/include/directx/d3d12shader.h
+++ b/include/directx/d3d12shader.h
@@ -143,6 +143,10 @@ typedef struct _D3D12_HULL_SHADER_DESC {
     FLOAT                                   MaxTessFactor;                // Max tessellation factor
 } D3D12_HULL_SHADER_DESC;
 
+typedef D3D_PRIMITIVE_TOPOLOGY D3D12_PRIMITIVE_TOPOLOGY;
+
+typedef D3D_PRIMITIVE D3D12_PRIMITIVE;
+
 typedef struct _D3D12_GEOMETRY_SHADER_DESC {
     D3D12_PRIMITIVE                         InputPrimitive;               // Input primitive
     UINT                                    MaxVertexCount;               // Max vertex count
@@ -162,52 +166,60 @@ typedef struct _D3D12_MESH_SHADER_DESC {
     D3D12_MESH_OUTPUT_TOPOLOGY              OutputTopology;               // Output topology
 } D3D12_MESH_SHADER_DESC;
 
-typedef struct _D3D12_SHADER_DESC
-{
-    UINT                                Version;                     // Shader version
-    LPCSTR                              Creator;                     // Creator string
-    UINT                                Flags;                       // Shader compilation/parse flags
-    						            
-    UINT                                ConstantBuffers;             // Number of constant buffers
-    UINT                                BoundResources;              // Number of bound resources
-    UINT                                InputParameters;             // Number of parameters in the input signature
-    UINT                                OutputParameters;            // Number of parameters in the output signature
-							            
-    UINT                                InstructionCount;            // Number of emitted instructions
-    UINT                                TempRegisterCount;           // Number of temporary registers used 
-    UINT                                TempArrayCount;              // Number of temporary arrays used
-    UINT                                DefCount;                    // Number of constant defines 
-    UINT                                DclCount;                    // Number of declarations (input + output)
-    UINT                                TextureNormalInstructions;   // Number of non-categorized texture instructions
-    UINT                                TextureLoadInstructions;     // Number of texture load instructions
-    UINT                                TextureCompInstructions;     // Number of texture comparison instructions
-    UINT                                TextureBiasInstructions;     // Number of texture bias instructions
-    UINT                                TextureGradientInstructions; // Number of texture gradient instructions
-    UINT                                FloatInstructionCount;       // Number of floating point arithmetic instructions used
-    UINT                                IntInstructionCount;         // Number of signed integer arithmetic instructions used
-    UINT                                UintInstructionCount;        // Number of unsigned integer arithmetic instructions used
-    UINT                                StaticFlowControlCount;      // Number of static flow control instructions used
-    UINT                                DynamicFlowControlCount;     // Number of dynamic flow control instructions used
-    UINT                                MacroInstructionCount;       // Number of macro instructions used
-    UINT                                ArrayInstructionCount;       // Number of array instructions used
-    UINT                                CutInstructionCount;         // Number of cut instructions used
-    UINT                                EmitInstructionCount;        // Number of emit instructions used
-							            
-    UINT                                cBarrierInstructions;        // Number of barrier instructions in a compute shader
-    UINT                                cInterlockedInstructions;    // Number of interlocked instructions
-    UINT                                cTextureStoreInstructions;   // Number of texture writes
-	
-    D3D12_SHADER_VERSION_TYPE           ShaderType;                  // Function's shader stage
+typedef struct _D3D12_SHADER_DESC {
 
-    union {
-        D3D12_HULL_SHADER_DESC          HullShader;                  // ShaderType == D3D12_SHVER_HULL_SHADER
-        D3D12_COMPUTE_SHADER_DESC       ComputeShader;               // ShaderType == D3D12_SHVER_COMPUTE_SHADER
-        D3D12_MESH_SHADER_DESC          MeshShader;                  // ShaderType == D3D12_SHVER_MESH_SHADER
-        D3D12_GEOMETRY_SHADER_DESC      GeometryShader;              // ShaderType == D3D12_SHVER_GEOMETRY_SHADER
-        D3D12_DOMAIN_SHADER_DESC        DomainShader;                // ShaderType == D3D12_SHVER_DOMAIN_SHADER
-        D3D12_AMPLIFICATION_SHADER_DESC AmplificationShader;         // ShaderType == D3D12_SHVER_AMPLIFICATION_SHADER
-        D3D12_PIXEL_SHADER_DESC         PixelShader;                 // ShaderType == D3D12_SHVER_PIXEL_SHADER
-    };
+    UINT Version;   // Shader version
+    LPCSTR Creator; // Creator string
+    UINT Flags;     // Shader compilation/parse flags
+
+    UINT ConstantBuffers;  // Number of constant buffers
+    UINT BoundResources;   // Number of bound resources
+    UINT InputParameters;  // Number of parameters in the input signature
+    UINT OutputParameters; // Number of parameters in the output signature
+
+    UINT InstructionCount;          // Number of emitted instructions
+    UINT TempRegisterCount;         // Number of temporary registers used
+    UINT TempArrayCount;            // Number of temporary arrays used
+    UINT DefCount;                  // Number of constant defines
+    UINT DclCount;                  // Number of declarations (input + output)
+    UINT TextureNormalInstructions; // Number of non-categorized texture
+                                    // instructions
+    UINT TextureLoadInstructions;   // Number of texture load instructions
+    UINT TextureCompInstructions;   // Number of texture comparison instructions
+    UINT TextureBiasInstructions;   // Number of texture bias instructions
+    UINT TextureGradientInstructions; // Number of texture gradient instructions
+    UINT FloatInstructionCount;       // Number of floating point arithmetic
+                                      // instructions used
+    UINT IntInstructionCount;         // Number of signed integer arithmetic
+                                      // instructions used
+    UINT UintInstructionCount;        // Number of unsigned integer arithmetic
+                                      // instructions used
+    UINT StaticFlowControlCount;  // Number of static flow control instructions
+                                  // used
+    UINT DynamicFlowControlCount; // Number of dynamic flow control instructions
+                                  // used
+    UINT MacroInstructionCount;   // Number of macro instructions used
+    UINT ArrayInstructionCount;   // Number of array instructions used
+    UINT CutInstructionCount;     // Number of cut instructions used
+    UINT EmitInstructionCount;    // Number of emit instructions used
+    D3D_PRIMITIVE_TOPOLOGY GSOutputTopology; // Geometry shader output topology
+    UINT GSMaxOutputVertexCount;  // Geometry shader maximum output vertex count
+    D3D_PRIMITIVE InputPrimitive; // GS/HS input primitive
+    UINT PatchConstantParameters; // Number of parameters in the patch constant
+                                  // signature
+    UINT cGSInstanceCount;        // Number of Geometry shader instances
+    UINT cControlPoints; // Number of control points in the HS->DS stage
+    D3D_TESSELLATOR_OUTPUT_PRIMITIVE
+        HSOutputPrimitive; // Primitive output by the tessellator
+    D3D_TESSELLATOR_PARTITIONING
+        HSPartitioning; // Partitioning mode of the tessellator
+    D3D_TESSELLATOR_DOMAIN
+        TessellatorDomain; // Domain of the tessellator (quad, tri, isoline)
+    // instruction counts
+    UINT cBarrierInstructions; // Number of barrier instructions in a compute
+                               // shader
+    UINT cInterlockedInstructions;  // Number of interlocked instructions
+    UINT cTextureStoreInstructions; // Number of texture writes
 
 } D3D12_SHADER_DESC;
 
@@ -267,8 +279,16 @@ typedef struct _D3D12_LIBRARY_DESC
     UINT      FunctionCount;     // Number of functions exported from the library.
 } D3D12_LIBRARY_DESC;
 
+typedef enum D3D12_NODE_OVERRIDES_TYPE {
+    D3D12_NODE_OVERRIDES_TYPE_NONE = 0,
+    D3D12_NODE_OVERRIDES_TYPE_BROADCASTING_LAUNCH = 1,
+    D3D12_NODE_OVERRIDES_TYPE_COALESCING_LAUNCH = 2,
+    D3D12_NODE_OVERRIDES_TYPE_THREAD_LAUNCH = 3,
+    D3D12_NODE_OVERRIDES_TYPE_COMMON_COMPUTE = 4
+} D3D12_NODE_OVERRIDES_TYPE;
+
 typedef struct _D3D12_NODE_SHADER_DESC {
-    D3D12_FUNCTION_COMPUTE_DESC             ComputeDesc;                  // Node extends ComputeDesc
+    D3D12_COMPUTE_SHADER_DESC               ComputeDesc;                  // Node extends ComputeDesc
     D3D12_NODE_OVERRIDES_TYPE               LaunchType;                   // Launch type
     BOOL                                    IsProgramEntry;               // Is program entry
     INT                                     LocalRootArgumentsTableIndex; // Local root arguments table index

--- a/include/directx/d3d12shader.h
+++ b/include/directx/d3d12shader.h
@@ -114,49 +114,101 @@ typedef D3D_TESSELLATOR_PARTITIONING D3D12_TESSELLATOR_PARTITIONING;
 
 typedef D3D_TESSELLATOR_OUTPUT_PRIMITIVE D3D12_TESSELLATOR_OUTPUT_PRIMITIVE;
 
+typedef struct _D3D12_COMPUTE_SHADER_DESC {
+    UINT                                    WaveSizeMin;                  // SM 6.8+ WaveSize(n, ..., ...) min, max, pref
+    UINT                                    WaveSizeMax;                  // SM 6.8+ WaveSize(..., n, ...) min, max, pref
+    UINT                                    WaveSizePreferred;            // SM 6.6 WaveSize(n) or WaveSize(.., ..., n)
+    UINT                                    NumThreads[3];                // numthreads(x, y, z)
+} D3D12_COMPUTE_SHADER_DESC;
+
+typedef struct _D3D12_AMPLIFICATION_SHADER_DESC {
+    UINT                                    PayloadSize;                  // Payload size in bytes
+} D3D12_AMPLIFICATION_SHADER_DESC;
+
+typedef struct _D3D12_PIXEL_SHADER_DESC {
+    BOOL                                    EarlyDepthStencil;            // Early depth stencil
+} D3D12_PIXEL_SHADER_DESC;
+
+typedef struct _D3D12_DOMAIN_SHADER_DESC {
+    D3D12_TESSELLATOR_DOMAIN                Domain;                       // Domain
+    UINT                                    InputControlPoints;           // Input control points
+} D3D12_DOMAIN_SHADER_DESC;
+
+typedef struct _D3D12_HULL_SHADER_DESC {
+    D3D12_TESSELLATOR_DOMAIN                Domain;                       // Domain
+    D3D12_TESSELLATOR_PARTITIONING          Partition;                    // Partition
+    D3D12_TESSELLATOR_OUTPUT_PRIMITIVE      OutputPrimitive;              // Output primitive
+    UINT                                    InputControlPoints;           // Input control points
+    UINT                                    OutputControlPoints;          // Output control points
+    FLOAT                                   MaxTessFactor;                // Max tessellation factor
+} D3D12_HULL_SHADER_DESC;
+
+typedef struct _D3D12_GEOMETRY_SHADER_DESC {
+    D3D12_PRIMITIVE                         InputPrimitive;               // Input primitive
+    UINT                                    MaxVertexCount;               // Max vertex count
+    UINT                                    InstanceCount;                // Instance count
+    D3D12_PRIMITIVE_TOPOLOGY                StreamPrimitiveTopologies[4]; // Stream primitive topologies
+} D3D12_GEOMETRY_SHADER_DESC;
+
+typedef enum D3D12_MESH_OUTPUT_TOPOLOGY {
+  D3D12_MESH_OUTPUT_TOPOLOGY_LINE = 1,
+  D3D12_MESH_OUTPUT_TOPOLOGY_TRIANGLE = 2
+} D3D12_MESH_OUTPUT_TOPOLOGY;
+
+typedef struct _D3D12_MESH_SHADER_DESC {
+    UINT                                    PayloadSize;                  // Payload size in bytes
+    UINT                                    MaxVertexCount;               // Max vertex count
+    UINT                                    MaxPrimitiveCount;            // Max primitive count
+    D3D12_MESH_OUTPUT_TOPOLOGY              OutputTopology;               // Output topology
+} D3D12_MESH_SHADER_DESC;
+
 typedef struct _D3D12_SHADER_DESC
 {
-    UINT                    Version;                     // Shader version
-    LPCSTR                  Creator;                     // Creator string
-    UINT                    Flags;                       // Shader compilation/parse flags
-    
-    UINT                    ConstantBuffers;             // Number of constant buffers
-    UINT                    BoundResources;              // Number of bound resources
-    UINT                    InputParameters;             // Number of parameters in the input signature
-    UINT                    OutputParameters;            // Number of parameters in the output signature
+    UINT                                Version;                     // Shader version
+    LPCSTR                              Creator;                     // Creator string
+    UINT                                Flags;                       // Shader compilation/parse flags
+    						            
+    UINT                                ConstantBuffers;             // Number of constant buffers
+    UINT                                BoundResources;              // Number of bound resources
+    UINT                                InputParameters;             // Number of parameters in the input signature
+    UINT                                OutputParameters;            // Number of parameters in the output signature
+							            
+    UINT                                InstructionCount;            // Number of emitted instructions
+    UINT                                TempRegisterCount;           // Number of temporary registers used 
+    UINT                                TempArrayCount;              // Number of temporary arrays used
+    UINT                                DefCount;                    // Number of constant defines 
+    UINT                                DclCount;                    // Number of declarations (input + output)
+    UINT                                TextureNormalInstructions;   // Number of non-categorized texture instructions
+    UINT                                TextureLoadInstructions;     // Number of texture load instructions
+    UINT                                TextureCompInstructions;     // Number of texture comparison instructions
+    UINT                                TextureBiasInstructions;     // Number of texture bias instructions
+    UINT                                TextureGradientInstructions; // Number of texture gradient instructions
+    UINT                                FloatInstructionCount;       // Number of floating point arithmetic instructions used
+    UINT                                IntInstructionCount;         // Number of signed integer arithmetic instructions used
+    UINT                                UintInstructionCount;        // Number of unsigned integer arithmetic instructions used
+    UINT                                StaticFlowControlCount;      // Number of static flow control instructions used
+    UINT                                DynamicFlowControlCount;     // Number of dynamic flow control instructions used
+    UINT                                MacroInstructionCount;       // Number of macro instructions used
+    UINT                                ArrayInstructionCount;       // Number of array instructions used
+    UINT                                CutInstructionCount;         // Number of cut instructions used
+    UINT                                EmitInstructionCount;        // Number of emit instructions used
+							            
+    UINT                                cBarrierInstructions;        // Number of barrier instructions in a compute shader
+    UINT                                cInterlockedInstructions;    // Number of interlocked instructions
+    UINT                                cTextureStoreInstructions;   // Number of texture writes
+	
+    D3D12_SHADER_VERSION_TYPE           ShaderType;                  // Function's shader stage
 
-    UINT                    InstructionCount;            // Number of emitted instructions
-    UINT                    TempRegisterCount;           // Number of temporary registers used 
-    UINT                    TempArrayCount;              // Number of temporary arrays used
-    UINT                    DefCount;                    // Number of constant defines 
-    UINT                    DclCount;                    // Number of declarations (input + output)
-    UINT                    TextureNormalInstructions;   // Number of non-categorized texture instructions
-    UINT                    TextureLoadInstructions;     // Number of texture load instructions
-    UINT                    TextureCompInstructions;     // Number of texture comparison instructions
-    UINT                    TextureBiasInstructions;     // Number of texture bias instructions
-    UINT                    TextureGradientInstructions; // Number of texture gradient instructions
-    UINT                    FloatInstructionCount;       // Number of floating point arithmetic instructions used
-    UINT                    IntInstructionCount;         // Number of signed integer arithmetic instructions used
-    UINT                    UintInstructionCount;        // Number of unsigned integer arithmetic instructions used
-    UINT                    StaticFlowControlCount;      // Number of static flow control instructions used
-    UINT                    DynamicFlowControlCount;     // Number of dynamic flow control instructions used
-    UINT                    MacroInstructionCount;       // Number of macro instructions used
-    UINT                    ArrayInstructionCount;       // Number of array instructions used
-    UINT                    CutInstructionCount;         // Number of cut instructions used
-    UINT                    EmitInstructionCount;        // Number of emit instructions used
-    D3D_PRIMITIVE_TOPOLOGY  GSOutputTopology;            // Geometry shader output topology
-    UINT                    GSMaxOutputVertexCount;      // Geometry shader maximum output vertex count
-    D3D_PRIMITIVE           InputPrimitive;              // GS/HS input primitive
-    UINT                    PatchConstantParameters;     // Number of parameters in the patch constant signature
-    UINT                    cGSInstanceCount;            // Number of Geometry shader instances
-    UINT                    cControlPoints;              // Number of control points in the HS->DS stage
-    D3D_TESSELLATOR_OUTPUT_PRIMITIVE HSOutputPrimitive;  // Primitive output by the tessellator
-    D3D_TESSELLATOR_PARTITIONING HSPartitioning;         // Partitioning mode of the tessellator
-    D3D_TESSELLATOR_DOMAIN  TessellatorDomain;           // Domain of the tessellator (quad, tri, isoline)
-    // instruction counts
-    UINT cBarrierInstructions;                           // Number of barrier instructions in a compute shader
-    UINT cInterlockedInstructions;                       // Number of interlocked instructions
-    UINT cTextureStoreInstructions;                      // Number of texture writes
+    union {
+        D3D12_HULL_SHADER_DESC          HullShader;                  // ShaderType == D3D12_SHVER_HULL_SHADER
+        D3D12_COMPUTE_SHADER_DESC       ComputeShader;               // ShaderType == D3D12_SHVER_COMPUTE_SHADER
+        D3D12_MESH_SHADER_DESC          MeshShader;                  // ShaderType == D3D12_SHVER_MESH_SHADER
+        D3D12_GEOMETRY_SHADER_DESC      GeometryShader;              // ShaderType == D3D12_SHVER_GEOMETRY_SHADER
+        D3D12_DOMAIN_SHADER_DESC        DomainShader;                // ShaderType == D3D12_SHVER_DOMAIN_SHADER
+        D3D12_AMPLIFICATION_SHADER_DESC AmplificationShader;         // ShaderType == D3D12_SHVER_AMPLIFICATION_SHADER
+        D3D12_PIXEL_SHADER_DESC         PixelShader;                 // ShaderType == D3D12_SHVER_PIXEL_SHADER
+    };
+
 } D3D12_SHADER_DESC;
 
 typedef struct _D3D12_SHADER_INPUT_BIND_DESC
@@ -215,14 +267,7 @@ typedef struct _D3D12_LIBRARY_DESC
     UINT      FunctionCount;     // Number of functions exported from the library.
 } D3D12_LIBRARY_DESC;
 
-typedef struct _D3D12_FUNCTION_COMPUTE_DESC {
-    UINT                                    WaveSizeMin;                  // SM 6.8+ WaveSize(n, ..., ...) min, max, pref
-    UINT                                    WaveSizeMax;                  // SM 6.8+ WaveSize(..., n, ...) min, max, pref
-    UINT                                    WaveSizePreferred;            // SM 6.6 WaveSize(n) or WaveSize(.., ..., n)
-    UINT                                    NumThreads[3];                // numthreads(x, y, z)
-} D3D12_FUNCTION_COMPUTE_DESC;
-
-typedef struct _D3D12_FUNCTION_NODE_DESC {
+typedef struct _D3D12_NODE_SHADER_DESC {
     D3D12_FUNCTION_COMPUTE_DESC             ComputeDesc;                  // Node extends ComputeDesc
     D3D12_NODE_OVERRIDES_TYPE               LaunchType;                   // Launch type
     BOOL                                    IsProgramEntry;               // Is program entry
@@ -230,53 +275,12 @@ typedef struct _D3D12_FUNCTION_NODE_DESC {
     UINT                                    DispatchGrid[3];              // Dispatch grid
     UINT                                    MaxDispatchGrid[3];           // Max dispatch grid
     UINT                                    MaxRecursionDepth;            // Max recursion depth
-} D3D12_FUNCTION_NODE_DESC;
+} D3D12_NODE_SHADER_DESC;
 
-typedef struct _D3D12_FUNCTION_RAYTRACING_DESC {
+typedef struct _D3D12_RAYTRACING_SHADER_DESC {
     UINT                                    ParamPayloadSize;             // Payload or param size (callable) in bytes
     UINT                                    AttributeSize;                // Attribute size in bytes
-} D3D12_FUNCTION_RAYTRACING_DESC;
-
-typedef struct _D3D12_FUNCTION_AMPLIFICATION_DESC {
-    UINT                                    PayloadSize;                  // Payload size in bytes
-} D3D12_FUNCTION_AMPLIFICATION_DESC;
-
-typedef struct _D3D12_FUNCTION_PIXEL_DESC {
-    BOOL                                    EarlyDepthStencil;            // Early depth stencil
-} D3D12_FUNCTION_PIXEL_DESC;
-
-typedef struct _D3D12_FUNCTION_DOMAIN_DESC {
-    D3D12_TESSELLATOR_DOMAIN                Domain;                       // Domain
-    UINT                                    InputControlPoints;           // Input control points
-} D3D12_FUNCTION_DOMAIN_DESC;
-
-typedef struct _D3D12_FUNCTION_HULL_DESC {
-    D3D12_TESSELLATOR_DOMAIN                Domain;                       // Domain
-    D3D12_TESSELLATOR_PARTITIONING          Partition;                    // Partition
-    D3D12_TESSELLATOR_OUTPUT_PRIMITIVE      OutputPrimitive;              // Output primitive
-    UINT                                    InputControlPoints;           // Input control points
-    UINT                                    OutputControlPoints;          // Output control points
-    FLOAT                                   MaxTessFactor;                // Max tessellation factor
-} D3D12_FUNCTION_HULL_DESC;
-
-typedef struct _D3D12_FUNCTION_GEOMETRY_DESC {
-    D3D12_PRIMITIVE                         InputPrimitive;               // Input primitive
-    UINT                                    MaxVertexCount;               // Max vertex count
-    UINT                                    InstanceCount;                // Instance count
-    D3D12_PRIMITIVE_TOPOLOGY                StreamPrimitiveTopologies[4]; // Stream primitive topologies
-} D3D12_FUNCTION_GEOMETRY_DESC;
-
-typedef enum D3D12_MESH_OUTPUT_TOPOLOGY {
-  D3D12_MESH_OUTPUT_TOPOLOGY_LINE = 1,
-  D3D12_MESH_OUTPUT_TOPOLOGY_TRIANGLE = 2
-} D3D12_MESH_OUTPUT_TOPOLOGY;
-
-typedef struct _D3D12_FUNCTION_MESH_DESC {
-    UINT                                    PayloadSize;                  // Payload size in bytes
-    UINT                                    MaxVertexCount;               // Max vertex count
-    UINT                                    MaxPrimitiveCount;            // Max primitive count
-    D3D12_MESH_OUTPUT_TOPOLOGY              OutputTopology;               // Output topology
-} D3D12_FUNCTION_MESH_DESC;
+} D3D12_RAYTRACING_SHADER_DESC;
 
 typedef struct _D3D12_FUNCTION_DESC
 {
@@ -320,15 +324,15 @@ typedef struct _D3D12_FUNCTION_DESC
     D3D12_SHADER_VERSION_TYPE               ShaderType;                   // Function's shader stage
 
     union {
-        D3D12_FUNCTION_NODE_DESC            NodeShader;                   // ShaderType == D3D12_SHVER_NODE_SHADER
-        D3D12_FUNCTION_HULL_DESC            HullShader;                   // ShaderType == D3D12_SHVER_HULL_SHADER
-        D3D12_FUNCTION_COMPUTE_DESC         ComputeShader;                // ShaderType == D3D12_SHVER_COMPUTE_SHADER
-        D3D12_FUNCTION_MESH_DESC            MeshShader;                   // ShaderType == D3D12_SHVER_MESH_SHADER
-        D3D12_FUNCTION_GEOMETRY_DESC        GeometryShader;               // ShaderType == D3D12_SHVER_GEOMETRY_SHADER
-        D3D12_FUNCTION_RAYTRACING_DESC      RaytracingShader;             // ShaderType > D3D12_SHVER_RAY_GENERATION_SHADER && <= D3D12_SHVER_CALLABLE_SHADER
-        D3D12_FUNCTION_DOMAIN_DESC          DomainShader;                 // ShaderType == D3D12_SHVER_DOMAIN_SHADER
-        D3D12_FUNCTION_AMPLIFICATION_DESC   AmplificationShader;          // ShaderType == D3D12_SHVER_AMPLIFICATION_SHADER
-        D3D12_FUNCTION_PIXEL_DESC           PixelShader;                  // ShaderType == D3D12_SHVER_PIXEL_SHADER
+        D3D12_NODE_SHADER_DESC              NodeShader;                   // ShaderType == D3D12_SHVER_NODE_SHADER
+        D3D12_HULL_SHADER_DESC              HullShader;                   // ShaderType == D3D12_SHVER_HULL_SHADER
+        D3D12_COMPUTE_SHADER_DESC           ComputeShader;                // ShaderType == D3D12_SHVER_COMPUTE_SHADER
+        D3D12_MESH_SHADER_DESC              MeshShader;                   // ShaderType == D3D12_SHVER_MESH_SHADER
+        D3D12_GEOMETRY_SHADER_DESC          GeometryShader;               // ShaderType == D3D12_SHVER_GEOMETRY_SHADER
+        D3D12_RAYTRACING_SHADER_DESC        RaytracingShader;             // ShaderType > D3D12_SHVER_RAY_GENERATION_SHADER && <= D3D12_SHVER_CALLABLE_SHADER
+        D3D12_DOMAIN_SHADER_DESC            DomainShader;                 // ShaderType == D3D12_SHVER_DOMAIN_SHADER
+        D3D12_AMPLIFICATION_SHADER_DESC     AmplificationShader;          // ShaderType == D3D12_SHVER_AMPLIFICATION_SHADER
+        D3D12_PIXEL_SHADER_DESC             PixelShader;                  // ShaderType == D3D12_SHVER_PIXEL_SHADER
     };
 
 } D3D12_FUNCTION_DESC;


### PR DESCRIPTION
The DXC backend has the following parameter:
```const DxilFunctionProps *m_pProps```
Which has a large number of members that are not accessible by ID3D12FunctionReflection and D3D12_FUNCTION_DESC.
The most interesting ones being raytracing and workgraph related.
Exposing these saves me a lot of headache, as I won't need to parse these manually, especially since they're already available in DXC.

The following parameters still need to be exposed (and I'll take a look later to add them):
- Serialized root signature could have a getter which returns a DxcBuffer.
- InputNodes / OutputNodes could have a getter which returns a CNodeIOProperties* and length. Where each CNodeIOProperties has const char* for name as well as UINT id.
- NodeID NodeShaderId, NodeShaderSharedInput could use UINT ids in the D3D12_NODE_SHADER_DESC struct, while leaving the strings as getters.

The following parameters I won't add, since I have no idea how to properly expose them and if they're even useful to the front end:
- Vertex reflection: clipPlanes[6] returns an llvm::Constant
- Hull reflection: returns patchConstFunction as llvm::Function, which won't be accessible.
Since these are llvm internal values, I'm guessing that they might not be very useful for the front end.

This relates to a DXCompiler issue & PR.