### PR TITLE
Update d3dx12_resource_helpers.h for /analyze warning

### DIFF
--- a/include/directx/d3dx12_resource_helpers.h
+++ b/include/directx/d3dx12_resource_helpers.h
@@ -460,7 +460,7 @@ inline bool D3DX12GetCopyableFootprints(
         UINT32 MinPlanePitchWidth, PlaneWidth, PlaneHeight;
         D3D12_PROPERTY_LAYOUT_FORMAT_TABLE::GetPlaneSubsampledSizeAndFormatForCopyableLayout(PlaneSlice, Format, (UINT)Width, Height, /*_Out_*/ PlaneFormat, /*_Out_*/ MinPlanePitchWidth, /* _Out_ */ PlaneWidth, /*_Out_*/ PlaneHeight);
 
-        D3D12_SUBRESOURCE_FOOTPRINT LocalPlacement;
+        D3D12_SUBRESOURCE_FOOTPRINT LocalPlacement = {};
         auto& Placement = pLayouts ? pLayouts[uSubRes].Footprint : LocalPlacement;
         Placement.Format = PlaneFormat;
         Placement.Width = PlaneWidth;


### PR DESCRIPTION
Fixes the following `/analyze` warning in this header with VS 2022:

```
D:\vcpkg\installed\x64-windows\include\directx\d3dx12_resource_helpers.h(555): error C2220: the following warning is treated as an error
D:\vcpkg\installed\x64-windows\include\directx\d3dx12_resource_helpers.h(464) : warning C6001: Using uninitialized memory 'LocalPlacement'.: Lines: 417, 418, 419, 421, 422, 424, 426, 427, 430, 432, 433, 434, 436, 438, 439, 441, 442, 444, 449, 451, 452, 454, 455, 456, 459, 460, 461, 463, 464, 465, 466, 467, 468, 471, 472, 480, 464
```