### PR TITLE
Handle out of bound access in D3DX12ParsePipelineStream

### DIFF
--- a/include/directx/d3dx12_pipeline_state_stream.h
+++ b/include/directx/d3dx12_pipeline_state_stream.h
@@ -1347,6 +1347,45 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
         return E_INVALIDARG;
     }
 
+    static const UINT SizesOfSubobject[] = {
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::pRootSignature), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::VS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_VS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::PS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::DS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::HS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_HS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::GS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_GS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::CS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::StreamOutput), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_STREAM_OUTPUT
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::BlendState), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::SampleMask), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_MASK
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::RasterizerState), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::InputLayout), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_INPUT_LAYOUT
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::IBStripCutValue), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_IB_STRIP_CUT_VALUE
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::PrimitiveTopologyType), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PRIMITIVE_TOPOLOGY
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::RTVFormats), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RENDER_TARGET_FORMATS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::DSVFormat), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL_FORMAT
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::SampleDesc), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_DESC
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::NodeMask), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::CachedPSO), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CACHED_PSO
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::Flags), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM::DepthStencilState), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM1::ViewInstancingDesc), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_VIEW_INSTANCING
+        0, // not used
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM2::AS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_AS
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM2::MS), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MS
+#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 606)
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM3::DepthStencilState), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL2
+#endif
+#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 608)
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM4::RasterizerState), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER1
+#endif
+#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 610)
+        sizeof(CD3DX12_PIPELINE_STATE_STREAM5::RasterizerState), // D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER2
+#endif
+    };
+    static_assert(_countof(SizesOfSubobject) == D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MAX_VALID, "Array size doesn't match D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MAX_VALID value");
+
     bool SubobjectSeen[D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MAX_VALID] = {};
     for (SIZE_T CurOffset = 0, SizeOfSubobject = 0; CurOffset < Desc.SizeInBytes; CurOffset += SizeOfSubobject)
     {
@@ -1362,102 +1401,7 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
             pCallbacks->ErrorDuplicateSubobject(SubobjectType);
             return E_INVALIDARG; // disallow subobject duplicates in a stream
         }
-        switch (SubobjectType)
-        {
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_ROOT_SIGNATURE:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::pRootSignature);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_VS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::VS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::PS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_HS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::HS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_GS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::GS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::CS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_STREAM_OUTPUT:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::StreamOutput);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_BLEND:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::BlendState);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_MASK:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::SampleMask);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::RasterizerState);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM_DEPTH_STENCIL);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_INPUT_LAYOUT:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::InputLayout);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_IB_STRIP_CUT_VALUE:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::IBStripCutValue);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_PRIMITIVE_TOPOLOGY:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::PrimitiveTopologyType);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RENDER_TARGET_FORMATS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::RTVFormats);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL_FORMAT:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DSVFormat);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_SAMPLE_DESC:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::SampleDesc);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_NODE_MASK:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::NodeMask);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_CACHED_PSO:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::CachedPSO);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_FLAGS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::Flags);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL1:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DepthStencilState);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_VIEW_INSTANCING:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM1::ViewInstancingDesc);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_AS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM2::AS);
-            break;
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_MS:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM2::MS);
-            break;
-#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 606)
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DEPTH_STENCIL2:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM3::DepthStencilState);
-            break;
-#endif
-#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 608)
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER1:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM4::RasterizerState);
-            break;
-#endif
-#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 610)
-        case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_RASTERIZER2:
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM5::RasterizerState);
-            break;
-#endif
-        default:
-            pCallbacks->ErrorUnknownSubobject(SubobjectType);
-            return E_INVALIDARG;
-        }
+        
         if (CurOffset + SizeOfSubobject > Desc.SizeInBytes)
             return E_INVALIDARG;
         SubobjectSeen[SubobjectType] = true;
@@ -1474,7 +1418,6 @@ inline HRESULT D3DX12ParsePipelineStream(const D3D12_PIPELINE_STATE_STREAM_DESC&
             break;
         case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_DS:
             pCallbacks->DSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::DS)*>(pStream));
-            SizeOfSubobject = sizeof(CD3DX12_PIPELINE_STATE_STREAM::DS);
             break;
         case D3D12_PIPELINE_STATE_SUBOBJECT_TYPE_HS:
             pCallbacks->HSCb(*reinterpret_cast<decltype(CD3DX12_PIPELINE_STATE_STREAM::HS)*>(pStream));


### PR DESCRIPTION
Hi, was working on some project that uses DirectX-Headers, launched it with Asan and catched out of bound reads. This pull request fixes it