### PR TITLE
Fix CD3DX12_UNORDERED_ACCESS_VIEW_DESC::RawBuffer

### DIFF
--- a/include/directx/d3dx12_core.h
+++ b/include/directx/d3dx12_core.h
@@ -1888,7 +1888,7 @@ struct CD3DX12_UNORDERED_ACCESS_VIEW_DESC : public D3D12_UNORDERED_ACCESS_VIEW_D
         UINT64 CounterOffsetInBytes = 0) noexcept
     {
         CD3DX12_UNORDERED_ACCESS_VIEW_DESC desc;
-        desc.Format = DXGI_FORMAT_R32_UINT;
+        desc.Format = DXGI_FORMAT_R32_TYPELESS;
         desc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
         desc.Buffer.FirstElement = FirstElement;
         desc.Buffer.NumElements = NumElements;


### PR DESCRIPTION
Changing the specified format for Raw Buffer UAVs from DXGI_FORMAT_R32_UINT to DXGI_FORMAT_R32_TYPELESS.

This is flagged by the debug layer and is specified in [the docs](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_buffer_uav_flags).

I did not change the SRV version because [the docs](https://learn.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_buffer_srv_flags) don't specify that as a requirement.