### PR TITLE
CD3DX12_SERIALIZED_ROOT_SIGNATURE_DESC missing compile guard

### DIFF
--- a/include/directx/d3dx12_core.h
+++ b/include/directx/d3dx12_core.h
@@ -2058,6 +2058,7 @@ struct CD3DX12_RT_FORMAT_ARRAY : public D3D12_RT_FORMAT_ARRAY
 };
 
 //------------------------------------------------------------------------------------------------
+#if defined(D3D12_SDK_VERSION) && (D3D12_SDK_VERSION >= 618)
 struct CD3DX12_SERIALIZED_ROOT_SIGNATURE_DESC : public D3D12_SERIALIZED_ROOT_SIGNATURE_DESC
 {
     CD3DX12_SERIALIZED_ROOT_SIGNATURE_DESC() = default;
@@ -2076,3 +2077,4 @@ struct CD3DX12_SERIALIZED_ROOT_SIGNATURE_DESC : public D3D12_SERIALIZED_ROOT_SIG
         SerializedBlobSizeInBytes = size;
     }
 };
+#endif

--- a/include/directx/d3dx12_state_object.h
+++ b/include/directx/d3dx12_state_object.h
@@ -28,13 +28,12 @@
 // contents.
 //
 //================================================================================================
-#include <list>
 #include <forward_list>
-#include <vector>
+#include <list>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
-#include <map>
 #ifndef D3DX12_USE_ATL
 #include <wrl/client.h>
 #define D3DX12_COM_PTR Microsoft::WRL::ComPtr


### PR DESCRIPTION
The use of `CD3DX12_SERIALIZED_ROOT_SIGNATURE_DESC` is guarded by >= 618, but there was no guard present for the class itself which requires `D3D12_SERIALIZED_ROOT_SIGNATURE_DESC` to exist. It was added in Windows SDK (28000).

> Also noticed `include vector` was listed twice.