### PR TITLE
Add libdir to CMake's pkgconfig file

### DIFF
--- a/cmake/DirectX-Headers.pc.in
+++ b/cmake/DirectX-Headers.pc.in
@@ -7,4 +7,4 @@ Description: Headers for using D3D12
 URL: https://github.com/microsoft/DirectX-Headers
 Version: @PROJECT_VERSION@
 Cflags: -I${includedir}
-Libs: -lDirectX-Headers -lDirectX-Guids
+Libs: -L${libdir} -lDirectX-Headers -lDirectX-Guids


### PR DESCRIPTION
Adds libdir to the pkgconfig template that CMake uses.
Allows meson to find the lib files in a non-system prefix when DirectX-Headers where built using CMake.